### PR TITLE
Module system fixes

### DIFF
--- a/EvoSC.sln
+++ b/EvoSC.sln
@@ -28,6 +28,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleModule", "src\Module
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvoSC.Commands.Tests", "tests\EvoSC.Commands.Tests\EvoSC.Commands.Tests.csproj", "{812778D8-BAEA-4045-8D5D-77AF0CE8401B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{0CD963D2-392E-4A42-A853-532F7497C305}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleModule", "examples\SimpleModule\SimpleModule.csproj", "{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +82,10 @@ Global
 		{812778D8-BAEA-4045-8D5D-77AF0CE8401B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{812778D8-BAEA-4045-8D5D-77AF0CE8401B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{812778D8-BAEA-4045-8D5D-77AF0CE8401B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,5 +100,6 @@ Global
 		{6B5E0AB1-6E1E-40B5-9AA9-DAE9E6545FD3} = {DC47658A-F421-4BA4-B617-090A7DFB3900}
 		{EB9804D1-3521-4FAB-BBEE-E41361B05A93} = {DC47658A-F421-4BA4-B617-090A7DFB3900}
 		{812778D8-BAEA-4045-8D5D-77AF0CE8401B} = {46D790A2-EA9B-44A0-ABD2-A2A2CDC670D4}
+		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8} = {0CD963D2-392E-4A42-A853-532F7497C305}
 	EndGlobalSection
 EndGlobal

--- a/EvoSC.sln
+++ b/EvoSC.sln
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{0C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleModule", "examples\SimpleModule\SimpleModule.csproj", "{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EvoSC.Modules.SourceGeneration", "src\EvoSC.Modules.SourceGeneration\EvoSC.Modules.SourceGeneration.csproj", "{5C281145-BAC2-4999-B88B-41CE288758E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEE1BE1A-4447-4BD5-B6CA-2228C64E9BC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C281145-BAC2-4999-B88B-41CE288758E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C281145-BAC2-4999-B88B-41CE288758E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C281145-BAC2-4999-B88B-41CE288758E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C281145-BAC2-4999-B88B-41CE288758E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/SimpleModule/Info.cs
+++ b/examples/SimpleModule/Info.cs
@@ -1,0 +1,7 @@
+﻿using EvoSC.Modules.Attributes;
+
+[assembly: ModuleIdentifier("SimpleModule")]
+[assembly: ModuleTitle("Simple Module")]
+[assembly: ModuleSummary("The most basic module for EvosC#.")]
+[assembly: ModuleVersion("1.0.0")]
+[assembly: ModuleAuthor("snixtho")]

--- a/examples/SimpleModule/Info.cs
+++ b/examples/SimpleModule/Info.cs
@@ -1,7 +1,0 @@
-﻿using EvoSC.Modules.Attributes;
-
-[assembly: ModuleIdentifier("SimpleModule")]
-[assembly: ModuleTitle("Simple Module")]
-[assembly: ModuleSummary("The most basic module for EvosC#.")]
-[assembly: ModuleVersion("1.0.0")]
-[assembly: ModuleAuthor("snixtho")]

--- a/examples/SimpleModule/SimpleModule.cs
+++ b/examples/SimpleModule/SimpleModule.cs
@@ -1,5 +1,7 @@
 ﻿using EvoSC.Modules;
 using EvoSC.Modules.Attributes;
+using EvoSC.Modules.Official.Player.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace SimpleModule;
 

--- a/examples/SimpleModule/SimpleModule.cs
+++ b/examples/SimpleModule/SimpleModule.cs
@@ -1,0 +1,19 @@
+﻿using EvoSC.Modules;
+using EvoSC.Modules.Attributes;
+
+namespace SimpleModule;
+
+[Module]
+public class SimpleModule : EvoScModule, IToggleable
+{
+    public Task Enable()
+    {
+        Console.WriteLine("Hello World!");
+        return Task.CompletedTask;
+    }
+
+    public Task Disable()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/examples/SimpleModule/SimpleModule.csproj
+++ b/examples/SimpleModule/SimpleModule.csproj
@@ -10,7 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\EvoSC.Modules\EvoSC.Modules.csproj" />
+        <ProjectReference Include="..\..\src\EvoSC.Modules.SourceGeneration\EvoSC.Modules.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\src\EvoSC.Modules\EvoSC.Modules.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/SimpleModule/SimpleModule.csproj
+++ b/examples/SimpleModule/SimpleModule.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\EvoSC.Modules.SourceGeneration\EvoSC.Modules.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\..\src\EvoSC.Modules\EvoSC.Modules.csproj" />
+        <ProjectReference Include="..\..\src\Modules\Player\Player.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/SimpleModule/SimpleModule.csproj
+++ b/examples/SimpleModule/SimpleModule.csproj
@@ -14,4 +14,10 @@
         <ProjectReference Include="..\..\src\EvoSC.Modules\EvoSC.Modules.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="info.toml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/examples/SimpleModule/SimpleModule.csproj
+++ b/examples/SimpleModule/SimpleModule.csproj
@@ -4,12 +4,13 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>EvoSC.Modules.Official.ExampleModule</RootNamespace>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <Authors>snixtho</Authors>
+        <Title>Simple Module</Title>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\EvoSC.Modules\EvoSC.Modules.csproj" />
+      <ProjectReference Include="..\..\src\EvoSC.Modules\EvoSC.Modules.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/SimpleModule/info.toml
+++ b/examples/SimpleModule/info.toml
@@ -1,0 +1,6 @@
+﻿[info]
+name = "SimpleModule"
+title = "Simple Module"
+summary = "The most basic module possible."
+version = "1.0.0"
+author = "snixtho"

--- a/src/EvoSC.Commands/ChatCommandManager.cs
+++ b/src/EvoSC.Commands/ChatCommandManager.cs
@@ -138,7 +138,7 @@ public class ChatCommandManager : IChatCommandManager
         
         if (!_cmds.ContainsKey(cmdName))
         {
-            throw new InvalidOperationException($"Command with name '{cmd.Name}' not found.");
+            throw new CommandNotFoundException(cmdName, false);
         }
 
         _cmds.Remove(cmdName);

--- a/src/EvoSC.Commands/ChatCommandManager.cs
+++ b/src/EvoSC.Commands/ChatCommandManager.cs
@@ -22,8 +22,9 @@ public class ChatCommandManager : IChatCommandManager
 {
     public static readonly string CommandPrefix = "/";
     
-    private readonly Dictionary<string, IChatCommand> _cmds;
-    private readonly Dictionary<string, string> _aliasMap;
+    private readonly Dictionary<string, IChatCommand> _cmds = new();
+    private readonly Dictionary<string, string> _aliasMap = new();
+    private readonly Dictionary<Type, List<IChatCommand>> _controllerCommands = new();
 
     private readonly ILogger<ChatCommandManager> _logger;
 
@@ -31,12 +32,15 @@ public class ChatCommandManager : IChatCommandManager
     public ChatCommandManager(ILogger<ChatCommandManager> logger)
     {
         _logger = logger;
-        _cmds = new Dictionary<string, IChatCommand>();
-        _aliasMap = new Dictionary<string, string>();
     }
     
     public void RegisterForController(Type controllerType)
     {
+        if (!_controllerCommands.ContainsKey(controllerType))
+        {
+            _controllerCommands[controllerType] = new List<IChatCommand>();
+        }
+        
         var methods = controllerType.GetMethods(ReflectionUtils.InstanceMethods);
 
         foreach (var method in methods)
@@ -50,7 +54,7 @@ public class ChatCommandManager : IChatCommandManager
 
             var aliasAttrs = method.GetCustomAttributes<CommandAliasAttribute>();
 
-            AddCommand(builder =>
+            var cmd = AddCommand(builder =>
             {
                 builder
                     .WithName(cmdAttr.Name)
@@ -65,6 +69,21 @@ public class ChatCommandManager : IChatCommandManager
                     builder.AddAlias(new CommandAlias(alias));
                 }
             });
+            
+            _controllerCommands[controllerType].Add(cmd);
+        }
+    }
+
+    public void UnregisterForController(Type controllerType)
+    {
+        if (!_controllerCommands.ContainsKey(controllerType))
+        {
+            return;
+        }
+        
+        foreach (var cmd in _controllerCommands[controllerType])
+        {
+            RemoveCommand(cmd);
         }
     }
 
@@ -102,11 +121,34 @@ public class ChatCommandManager : IChatCommandManager
         }
     }
 
-    public void AddCommand(Action<ChatCommandBuilder> builderAction)
+    public IChatCommand AddCommand(Action<ChatCommandBuilder> builderAction)
     {
         var builder = new ChatCommandBuilder();
         builderAction(builder);
-        AddCommand(builder.Build());
+        var cmd = builder.Build();
+        
+        AddCommand(cmd);
+        
+        return cmd;
+    }
+
+    public void RemoveCommand(IChatCommand cmd)
+    {
+        var cmdName = (cmd.UsePrefix ? CommandPrefix : "") + cmd.Name; 
+        
+        if (!_cmds.ContainsKey(cmdName))
+        {
+            throw new InvalidOperationException($"Command with name '{cmd.Name}' not found.");
+        }
+
+        _cmds.Remove(cmdName);
+
+        foreach (var alias in cmd.Aliases.Keys)
+        {
+            _aliasMap.Remove(alias);
+        }
+
+        _logger.LogDebug("Removed command: {Name}", cmdName);
     }
 
     public IChatCommand FindCommand(string alias) => FindCommand(alias, true);

--- a/src/EvoSC.Commands/Interfaces/IChatCommandManager.cs
+++ b/src/EvoSC.Commands/Interfaces/IChatCommandManager.cs
@@ -13,7 +13,9 @@ public interface IChatCommandManager : IControllerActionRegistry
     /// Register a new chat command with a builder action.
     /// </summary>
     /// <param name="builder">An action or lambda that provides the command builder.</param>
-    public void AddCommand(Action<ChatCommandBuilder> builder);
+    public IChatCommand AddCommand(Action<ChatCommandBuilder> builder);
+
+    public void RemoveCommand(IChatCommand cmd);
     /// <summary>
     /// Find a command by it's name.
     /// </summary>

--- a/src/EvoSC.Common/Config/Models/IEvoScBaseConfig.cs
+++ b/src/EvoSC.Common/Config/Models/IEvoScBaseConfig.cs
@@ -6,4 +6,5 @@ public interface IEvoScBaseConfig
     public ILoggingConfig Logging { get; set; }
     public IServerConfig Server { get; set; }
     public IThemeConfig Theme { get; set; }
+    public IModuleConfig Modules { get; set; }
 }

--- a/src/EvoSC.Common/Config/Models/IModuleConfig.cs
+++ b/src/EvoSC.Common/Config/Models/IModuleConfig.cs
@@ -5,7 +5,12 @@ namespace EvoSC.Common.Config.Models;
 
 public interface IModuleConfig
 {
-    [Description("Signature verification of module's files. If enabled and verification fails, the module will not load.")]
+    [Description(
+        "Signature verification of module's files. If enabled and verification fails, the module will not load.")]
     [Option(Alias = "requireSignatureVerification", DefaultValue = true)]
     public bool RequireSignatureVerification { get; }
+
+    [Description("Directories to scan for external modules.")]
+    [Option(Alias = "moduleDirectories")]
+    public IEnumerable<string> ModuleDirectories { get; }
 }

--- a/src/EvoSC.Common/Config/Models/IModuleConfig.cs
+++ b/src/EvoSC.Common/Config/Models/IModuleConfig.cs
@@ -11,6 +11,6 @@ public interface IModuleConfig
     public bool RequireSignatureVerification { get; }
 
     [Description("Directories to scan for external modules.")]
-    [Option(Alias = "moduleDirectories")]
+    [Option(Alias = "moduleDirectories", DefaultValue = "modules")]
     public IEnumerable<string> ModuleDirectories { get; }
 }

--- a/src/EvoSC.Common/Config/Models/IModuleConfig.cs
+++ b/src/EvoSC.Common/Config/Models/IModuleConfig.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+using Config.Net;
+
+namespace EvoSC.Common.Config.Models;
+
+public interface IModuleConfig
+{
+    [Description("Signature verification of module's files. If enabled and verification fails, the module will not load.")]
+    [Option(Alias = "requireSignatureVerification", DefaultValue = true)]
+    public bool RequireSignatureVerification { get; }
+}

--- a/src/EvoSC.Common/Config/Stores/TomlConfigStore.cs
+++ b/src/EvoSC.Common/Config/Stores/TomlConfigStore.cs
@@ -82,7 +82,6 @@ public class TomlConfigStore<TConfig> : IConfigStore where TConfig : class
     {
         var value = _document.GetValue(key) as TomlArray;
 
-        // return string.Join(" ", value.Select(v => $"\"{v.StringValue.Replace("\"", "\"\"")}\""));
         return string.Join(" ", value.Select(v => v.StringValue));
     }
     
@@ -97,29 +96,12 @@ public class TomlConfigStore<TConfig> : IConfigStore where TConfig : class
         }
         else if (key.EndsWith("]"))
         {
-            //return GetArrayValue(key[..key.IndexOf("[")]);
-            
             var indexStart = key.IndexOf("[", StringComparison.Ordinal);
             var index = int.Parse(key[(indexStart+1)..^1]);
             var value = _document.GetValue(key[..indexStart]) as TomlArray;
 
             return value?.Skip(index)?.FirstOrDefault()?.StringValue;
         }
-        
-        /* if (key.EndsWith("$l"))
-        {
-            var value = _document.GetValue(key[..^3]) as TomlArray;
-
-            return string.Join(",", value.Select(v => v.StringValue));
-        }
-        else if (key.EndsWith("]"))
-        {
-            var indexStart = key.IndexOf("[");
-            var index = int.Parse(key[(indexStart+1)..^1]);
-            var value = _document.GetValue(key[..indexStart]) as TomlArray;
-
-            return value.Skip(index).FirstOrDefault().StringValue;
-        } */
 
         return _document.GetValue(key).StringValue;
     }

--- a/src/EvoSC.Common/Controllers/ControllerManager.cs
+++ b/src/EvoSC.Common/Controllers/ControllerManager.cs
@@ -73,6 +73,11 @@ public class ControllerManager : IControllerManager
             throw new ControllerException("Controller not found.");
         }
 
+        foreach (var registry in _registries)
+        {
+            registry.UnregisterForController(controllerType);
+        }
+
         _controllers.Remove(controllerType);
 
         if (_instances.ContainsKey(controllerType))

--- a/src/EvoSC.Common/Events/EventManager.cs
+++ b/src/EvoSC.Common/Events/EventManager.cs
@@ -52,6 +52,12 @@ public class EventManager : IEventManager
         });
         _subscriptions[subscription.Name].Sort((a, b) =>
             a.RunAsync ? -1 : (b.RunAsync ? 1 : 0));
+
+        _logger.LogDebug("Subscribed to event '{Name}' with handler '{Handler}' in class '{Class}'. In Controller: {IsController}",
+            subscription.Name,
+            subscription.HandlerMethod,
+            subscription.InstanceClass,
+            subscription.IsController);
     }
 
     public void Subscribe(Action<EventSubscriptionBuilder> builderAction)
@@ -84,6 +90,10 @@ public class EventManager : IEventManager
 
         _subscriptions[subscription.Name].Remove(subscription);
 
+        _logger.LogDebug("handler '{Handler}' unsubscribed to event {Name}.",
+            subscription.HandlerMethod,
+            subscription.Name);
+
         if (_subscriptions[subscription.Name].Count == 0)
         {
             _subscriptions.Remove(subscription.Name);
@@ -106,6 +116,8 @@ public class EventManager : IEventManager
             return;
         }
 
+        _logger.LogTrace("Attempting to fire event '{Event}'", name);
+        
         var tasks = InvokeEventTasks(name, args, sender ?? this);
         await WaitEventTasks(tasks);
     }

--- a/src/EvoSC.Common/Events/EventSubscription.cs
+++ b/src/EvoSC.Common/Events/EventSubscription.cs
@@ -52,4 +52,9 @@ public class EventSubscription : IEquatable<EventSubscription>
     {
         return HandlerMethod.GetHashCode();
     }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as EventSubscription);
+    }
 }

--- a/src/EvoSC.Common/EvoSC.Common.csproj
+++ b/src/EvoSC.Common/EvoSC.Common.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="FluentMigrator" Version="3.3.2" />
       <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
       <PackageReference Include="GbxRemote.Net" Version="3.0.1" />
+      <PackageReference Include="Humanizer.Core" Version="2.14.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
       <PackageReference Include="MySqlConnector" Version="2.2.0" />

--- a/src/EvoSC.Common/EvoSC.Common.csproj
+++ b/src/EvoSC.Common/EvoSC.Common.csproj
@@ -16,7 +16,7 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
       <PackageReference Include="MySqlConnector" Version="2.2.0" />
-      <PackageReference Include="Samboy063.Tomlet" Version="5.0.0" />
+      <PackageReference Include="Samboy063.Tomlet" Version="5.0.1" />
       <PackageReference Include="SimpleInjector" Version="5.4.1" />
     </ItemGroup>
 

--- a/src/EvoSC.Common/Interfaces/Controllers/IControllerActionRegistry.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IControllerActionRegistry.cs
@@ -8,5 +8,9 @@ public interface IControllerActionRegistry
     /// <param name="controllerType">The type of the controller's class.</param>
     public void RegisterForController(Type controllerType);
 
+    /// <summary>
+    /// Unregisters actions of a controller for the current registry.
+    /// </summary>
+    /// <param name="controllerType">The type of the controller's class.</param>
     public void UnregisterForController(Type controllerType);
 }

--- a/src/EvoSC.Common/Interfaces/Controllers/IControllerActionRegistry.cs
+++ b/src/EvoSC.Common/Interfaces/Controllers/IControllerActionRegistry.cs
@@ -7,4 +7,6 @@ public interface IControllerActionRegistry
     /// </summary>
     /// <param name="controllerType">The type of the controller's class.</param>
     public void RegisterForController(Type controllerType);
+
+    public void UnregisterForController(Type controllerType);
 }

--- a/src/EvoSC.Modules.SourceGeneration/AssemblyModuleInfoGenerator.cs
+++ b/src/EvoSC.Modules.SourceGeneration/AssemblyModuleInfoGenerator.cs
@@ -9,6 +9,11 @@ using Tomlet;
 
 namespace EvoSC.Modules.SourceGeneration
 {
+    /// <summary>
+    /// Generates an Info.g.cs file from an info.toml file. The file contains assembly information
+    /// for a module which is mostly used for loading internal modules. It gives a way to seamlessly
+    /// implement internal and external modules together to ease with development.
+    /// </summary>
     [Generator]
     public class AssemblyModuleInfoGenerator : ISourceGenerator
     {

--- a/src/EvoSC.Modules.SourceGeneration/AssemblyModuleInfoGenerator.cs
+++ b/src/EvoSC.Modules.SourceGeneration/AssemblyModuleInfoGenerator.cs
@@ -30,7 +30,7 @@ namespace EvoSC.Modules.SourceGeneration
             
             errorMessage.AppendLine($"#error Source Generator Error (Module: {context.Compilation.Assembly.Name}): ");
             errorMessage.AppendLine("#error Failed to generate the module's assembly info.");
-            errorMessage.AppendLine("#error You must provide a info.toml file in the module's root namespace.");
+            errorMessage.AppendLine("#error You must provide a \"info.toml\" file in the module's root namespace.");
             errorMessage.AppendLine("#error For more information, refer to the module documentation.");
             errorMessage.AppendLine();
             errorMessage.AppendLine($"#error Module directory: {dir ?? "<does not exist>"}");

--- a/src/EvoSC.Modules.SourceGeneration/AssemblyModuleInfoGenerator.cs
+++ b/src/EvoSC.Modules.SourceGeneration/AssemblyModuleInfoGenerator.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Tomlet;
+
+namespace EvoSC.Modules.SourceGeneration
+{
+    [Generator]
+    public class AssemblyModuleInfoGenerator : ISourceGenerator
+    {
+        public void Initialize(GeneratorInitializationContext context)
+        {
+            // not needed for this
+        }
+
+        private void FileNotFoundError(GeneratorExecutionContext context)
+        {
+            var errorMessage = new StringBuilder();
+
+            context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.projectdir", out var dir);
+            
+            errorMessage.AppendLine($"#error Source Generator Error (Module: {context.Compilation.Assembly.Name}): ");
+            errorMessage.AppendLine("#error Failed to generate the module's assembly info.");
+            errorMessage.AppendLine("#error You must provide a info.toml file in the module's root namespace.");
+            errorMessage.AppendLine("#error For more information, refer to the module documentation.");
+            errorMessage.AppendLine();
+            errorMessage.AppendLine($"#error Module directory: {dir ?? "<does not exist>"}");
+                
+            context.AddSource("Info.g.cs", errorMessage.ToString());
+        }
+
+        private void ParserError(GeneratorExecutionContext context, string message)
+        {
+            var errorMessage = new StringBuilder();
+                
+            errorMessage.AppendLine("#error Source Generator Error: ");
+            errorMessage.AppendLine("#error Failed to generate the module's assembly info.");
+            errorMessage.AppendLine($"#error Failed to parse info.toml: {message}");
+                
+            context.AddSource("Info.g.cs", errorMessage.ToString());
+        }
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.projectdir", out var dir);
+
+            if (dir == null)
+            {
+                return;
+            }
+            
+            var infoFile = Path.Combine(dir, "info.toml");
+
+            if (!File.Exists(infoFile))
+            {
+                FileNotFoundError(context);
+                return;
+            }
+
+            try
+            {
+                var document = TomlParser.ParseFile(infoFile);
+
+                var moduleIdentifier = document.GetValue("info.name").StringValue;
+                var moduleTitle = document.GetValue("info.title").StringValue;
+                var moduleSummary = document.GetValue("info.summary").StringValue;
+                var moduleVersion = document.GetValue("info.version").StringValue;
+                var moduleAuthor = document.GetValue("info.author").StringValue;
+
+                var source = new StringBuilder();
+
+                source.AppendLine("using EvoSC.Modules.Attributes;");
+                source.AppendLine();
+                source.AppendLine($"[assembly: ModuleIdentifier(\"{moduleIdentifier}\")]");
+                source.AppendLine($"[assembly: ModuleTitle(\"{moduleTitle}\")]");
+                source.AppendLine($"[assembly: ModuleSummary(\"{moduleSummary}\")]");
+                source.AppendLine($"[assembly: ModuleVersion(\"{moduleVersion}\")]");
+                source.AppendLine($"[assembly: ModuleAuthor(\"{moduleAuthor}\")]");
+
+                context.AddSource("Info.g.cs", source.ToString());
+            }
+            catch (Exception ex)
+            {
+                ParserError(context, ex.Message);
+            }
+        }
+    }
+}

--- a/src/EvoSC.Modules.SourceGeneration/EvoSC.Modules.SourceGeneration.csproj
+++ b/src/EvoSC.Modules.SourceGeneration/EvoSC.Modules.SourceGeneration.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Samboy063.Tomlet" Version="5.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
+    </PropertyGroup>
+
+    <Target Name="GetDependencyTargetPaths">
+        <ItemGroup>
+            <TargetPathWithTargetPlatformMoniker Include="$(PkgSamboy063_Tomlet)\lib\netstandard2.0\Tomlet.dll" IncludeRuntimeDependency="false" />
+        </ItemGroup>
+    </Target>
+</Project>

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleAuthorAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleAuthorAttribute.cs
@@ -3,6 +3,9 @@
 [AttributeUsage(AttributeTargets.Assembly)]
 public class ModuleAuthorAttribute : Attribute
 {
+    /// <summary>
+    /// The module's author.
+    /// </summary>
     public string Author { get; }
 
     public ModuleAuthorAttribute(string author)

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleAuthorAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleAuthorAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EvoSC.Modules.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+public class ModuleAuthorAttribute : Attribute
+{
+    public string Author { get; }
+
+    public ModuleAuthorAttribute(string author)
+    {
+        Author = author;
+    }
+}

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleDependencyAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleDependencyAttribute.cs
@@ -3,7 +3,14 @@
 [AttributeUsage(AttributeTargets.Assembly)]
 public class ModuleDependencyAttribute : Attribute
 {
+    /// <summary>
+    /// The identifier name of the dependency.
+    /// </summary>
     public string Name { get; }
+    
+    /// <summary>
+    /// The version required for this dependency.
+    /// </summary>
     public string RequiredVersion { get; }
 
     public ModuleDependencyAttribute(string name, string requiredVersion)

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleDependencyAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleDependencyAttribute.cs
@@ -1,0 +1,14 @@
+﻿namespace EvoSC.Modules.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+public class ModuleDependencyAttribute : Attribute
+{
+    public string Name { get; }
+    public string RequiredVersion { get; }
+
+    public ModuleDependencyAttribute(string name, string requiredVersion)
+    {
+        Name = name;
+        RequiredVersion = requiredVersion;
+    }
+}

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleIdentifierAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleIdentifierAttribute.cs
@@ -3,6 +3,9 @@
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 public class ModuleIdentifierAttribute : Attribute
 {
+    /// <summary>
+    /// The name of the module.
+    /// </summary>
     public string Name { get; }
 
     public ModuleIdentifierAttribute(string name)

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleIdentifierAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleIdentifierAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EvoSC.Modules.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class ModuleIdentifierAttribute : Attribute
+{
+    public string Name { get; }
+
+    public ModuleIdentifierAttribute(string name)
+    {
+        Name = name;
+    }
+}

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleSummaryAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleSummaryAttribute.cs
@@ -3,6 +3,9 @@
 [AttributeUsage(AttributeTargets.Assembly)]
 public class ModuleSummaryAttribute : Attribute
 {
+    /// <summary>
+    /// A short description of the module.
+    /// </summary>
     public string Summary { get; }
 
     public ModuleSummaryAttribute(string summary)

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleSummaryAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleSummaryAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EvoSC.Modules.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+public class ModuleSummaryAttribute : Attribute
+{
+    public string Summary { get; }
+
+    public ModuleSummaryAttribute(string summary)
+    {
+        Summary = summary;
+    }
+}

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleTitleAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleTitleAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EvoSC.Modules.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+public class ModuleTitleAttribute : Attribute
+{
+    public string Title { get; }
+
+    public ModuleTitleAttribute(string title)
+    {
+        Title = title;
+    }
+}

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleTitleAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleTitleAttribute.cs
@@ -3,6 +3,9 @@
 [AttributeUsage(AttributeTargets.Assembly)]
 public class ModuleTitleAttribute : Attribute
 {
+    /// <summary>
+    /// The title of the module.
+    /// </summary>
     public string Title { get; }
 
     public ModuleTitleAttribute(string title)

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleVersionAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleVersionAttribute.cs
@@ -3,6 +3,9 @@
 [AttributeUsage(AttributeTargets.Assembly)]
 public class ModuleVersionAttribute : Attribute
 {
+    /// <summary>
+    /// The current version of the module.
+    /// </summary>
     public Version Version { get; }
 
     public ModuleVersionAttribute(string version)

--- a/src/EvoSC.Modules/Attributes/Assembly/ModuleVersionAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/Assembly/ModuleVersionAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EvoSC.Modules.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+public class ModuleVersionAttribute : Attribute
+{
+    public Version Version { get; }
+
+    public ModuleVersionAttribute(string version)
+    {
+        this.Version = Version.Parse(version);
+    }
+}

--- a/src/EvoSC.Modules/Attributes/ModuleAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/ModuleAttribute.cs
@@ -7,14 +7,6 @@
 public class ModuleAttribute : Attribute
 {
     /// <summary>
-    /// Unique name of the module.
-    /// </summary>
-    public required string Name { get; init; }
-    /// <summary>
-    /// A summary of what the module is and does.
-    /// </summary>
-    public required string Description { get; init; }
-    /// <summary>
     /// Whether this is an internal module or not.
     /// </summary>
     public bool IsInternal { get; init; }

--- a/src/EvoSC.Modules/Attributes/RequireDependencyAttribute.cs
+++ b/src/EvoSC.Modules/Attributes/RequireDependencyAttribute.cs
@@ -10,6 +10,7 @@ public class RequireDependencyAttribute : Attribute
     /// Name of the module that is dependent upon.
     /// </summary>
     public required string Name { get; set; }
+    
     /// <summary>
     /// A specific version of the dependency that is required.
     /// </summary>

--- a/src/EvoSC.Modules/EvoSC.Modules.csproj
+++ b/src/EvoSC.Modules/EvoSC.Modules.csproj
@@ -15,4 +15,8 @@
       <ProjectReference Include="..\EvoSC.Common\EvoSC.Common.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Info" />
+    </ItemGroup>
+
 </Project>

--- a/src/EvoSC.Modules/Exceptions/MissingModulePropertyException.cs
+++ b/src/EvoSC.Modules/Exceptions/MissingModulePropertyException.cs
@@ -1,0 +1,15 @@
+﻿namespace EvoSC.Modules.Exceptions;
+
+public class MissingModulePropertyException : EvoScModuleException
+{
+    /// <summary>
+    /// The property name that was invalid.
+    /// </summary>
+    public string PropertyName { get; }
+
+    public MissingModulePropertyException(string name) : base(
+        $"The module is missing meta information. The {name} property was not found.")
+    {
+        PropertyName = name;
+    }
+}

--- a/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyCycleException.cs
+++ b/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyCycleException.cs
@@ -1,0 +1,59 @@
+﻿namespace EvoSC.Modules.Exceptions.ModuleDependency;
+
+using DependencyGraph = Dictionary<string, IList<string>>;
+
+public class DependencyCycleException : DependencyException
+{
+    private readonly DependencyGraph _remainingGraph;
+    
+    public DependencyCycleException(DependencyGraph remainingGraph)
+    {
+        _remainingGraph = remainingGraph;
+    }
+
+    private bool FindCycle(string name, List<string> visited)
+    {
+        if (visited.Contains(name))
+        {
+            // cycle
+            return true;
+        }
+        
+        visited.Add(name);
+
+        foreach (var dep in _remainingGraph[name])
+        {
+            if (FindCycle(dep, visited))
+            {
+                return true;
+            }
+        }
+
+        visited.Remove(name);
+
+        return false;
+    }
+
+    /// <summary>
+    /// A list representing the path of dependencies that leads to a cycle.
+    /// The last element is equal to the first.
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<string> GetCycle()
+    {
+        foreach (var name in _remainingGraph.Keys)
+        {
+            var cycle = new List<string>();
+            
+            if (FindCycle(_remainingGraph.FirstOrDefault().Key, cycle))
+            {
+                cycle.Add(name);
+                return cycle;
+            }
+        }
+
+        return Array.Empty<string>();
+    }
+
+    public override string Message { get => $"Dependency cycle detected: {string.Join(" -> ", GetCycle())}"; }
+}

--- a/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyException.cs
+++ b/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyException.cs
@@ -1,0 +1,8 @@
+﻿namespace EvoSC.Modules.Exceptions.ModuleDependency;
+
+public class DependencyException : EvoScModuleException
+{
+    public DependencyException(){}
+    public DependencyException(string message) : base(message){}
+    public DependencyException(string message, Exception innerException) : base(message, innerException){}
+}

--- a/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyNotFoundException.cs
+++ b/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyNotFoundException.cs
@@ -1,0 +1,14 @@
+﻿namespace EvoSC.Modules.Exceptions.ModuleDependency;
+
+public class DependencyNotFoundException : DependencyException
+{
+    public string Dependent { get; }
+    public string Dependency { get; }
+
+    public DependencyNotFoundException(string dependent, string dependency) : base(
+        $"The module '{dependent}' depend on '{dependency}' which doesn't exist.")
+    {
+        Dependent = dependent;
+        Dependency = dependency;
+    }
+}

--- a/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyNotFoundException.cs
+++ b/src/EvoSC.Modules/Exceptions/ModuleDependency/DependencyNotFoundException.cs
@@ -2,7 +2,13 @@
 
 public class DependencyNotFoundException : DependencyException
 {
+    /// <summary>
+    /// The module that has a the non-existent dependency.
+    /// </summary>
     public string Dependent { get; }
+    /// <summary>
+    /// The dependency that was not found for the dependent.
+    /// </summary>
     public string Dependency { get; }
 
     public DependencyNotFoundException(string dependent, string dependency) : base(

--- a/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+public interface IExternalModuleInfo : IModuleInfo
+{
+    public DirectoryInfo Directory { get; }
+}

--- a/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
@@ -6,7 +6,18 @@ public interface IExternalModuleInfo : IModuleInfo
 {
     bool IModuleInfo.IsInternal => false;
 
+    /// <summary>
+    /// The directory which this module resides in.
+    /// </summary>
     public DirectoryInfo Directory { get; }
+    
+    /// <summary>
+    /// All files related to this module.
+    /// </summary>
     public IEnumerable<IModuleFile> ModuleFiles { get; }
+    
+    /// <summary>
+    /// All assembly (.dll) files for this module.
+    /// </summary>
     public IEnumerable<IModuleFile> AssemblyFiles => ModuleFiles.Where(f => f.IsAssembly);
 }

--- a/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
@@ -2,5 +2,7 @@
 
 public interface IExternalModuleInfo : IModuleInfo
 {
+    bool IModuleInfo.IsInternal => false;
+
     public DirectoryInfo Directory { get; }
 }

--- a/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IExternalModuleInfo.cs
@@ -1,8 +1,12 @@
-﻿namespace EvoSC.Modules.Interfaces;
+﻿using EvoSC.Modules.Models;
+
+namespace EvoSC.Modules.Interfaces;
 
 public interface IExternalModuleInfo : IModuleInfo
 {
     bool IModuleInfo.IsInternal => false;
 
     public DirectoryInfo Directory { get; }
+    public IEnumerable<IModuleFile> ModuleFiles { get; }
+    public IEnumerable<IModuleFile> AssemblyFiles => ModuleFiles.Where(f => f.IsAssembly);
 }

--- a/src/EvoSC.Modules/Interfaces/IInstallable.cs
+++ b/src/EvoSC.Modules/Interfaces/IInstallable.cs
@@ -1,0 +1,19 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+/// <summary>
+/// Allows the plugin to provide custom install and uninstall code.
+/// </summary>
+public interface IInstallable
+{
+    /// <summary>
+    /// Install the module.
+    /// </summary>
+    /// <returns></returns>
+    public Task Install();
+    
+    /// <summary>
+    /// Uninstall the modules
+    /// </summary>
+    /// <returns></returns>
+    public Task Uninstall();
+}

--- a/src/EvoSC.Modules/Interfaces/IInternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IInternalModuleInfo.cs
@@ -5,5 +5,9 @@ namespace EvoSC.Modules.Interfaces;
 public interface IInternalModuleInfo : IModuleInfo
 {
     bool IModuleInfo.IsInternal => true;
+    
+    /// <summary>
+    /// The assembly this module is attached to.
+    /// </summary>
     public Assembly Assembly { get; }
 }

--- a/src/EvoSC.Modules/Interfaces/IInternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IInternalModuleInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+public interface IInternalModuleInfo : IModuleInfo
+{
+    bool IModuleInfo.IsInternal => true;
+}

--- a/src/EvoSC.Modules/Interfaces/IInternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IInternalModuleInfo.cs
@@ -1,6 +1,9 @@
-﻿namespace EvoSC.Modules.Interfaces;
+﻿using System.Reflection;
+
+namespace EvoSC.Modules.Interfaces;
 
 public interface IInternalModuleInfo : IModuleInfo
 {
     bool IModuleInfo.IsInternal => true;
+    public Assembly Assembly { get; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleCollection.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleCollection.cs
@@ -1,0 +1,10 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+public interface IModuleCollection<T> : IEnumerable<T> where T : IModuleInfo
+{
+    /// <summary>
+    /// Add a new module to the collection.
+    /// </summary>
+    /// <param name="module">The module to add.</param>
+    public void Add(T module);
+}

--- a/src/EvoSC.Modules/Interfaces/IModuleDependency.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleDependency.cs
@@ -1,0 +1,7 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+public interface IModuleDependency
+{
+    public string Name { get; }
+    public Version Version { get; }
+}

--- a/src/EvoSC.Modules/Interfaces/IModuleDependency.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleDependency.cs
@@ -2,6 +2,12 @@
 
 public interface IModuleDependency
 {
+    /// <summary>
+    /// The module's unique identifier name.
+    /// </summary>
     public string Name { get; }
+    /// <summary>
+    /// The version required for this module.
+    /// </summary>
     public Version Version { get; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleFile.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleFile.cs
@@ -1,0 +1,10 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+public interface IModuleFile
+{
+    public FileInfo File { get; }
+
+    public bool IsAssembly => File.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase);
+
+    public bool VerifySignature();
+}

--- a/src/EvoSC.Modules/Interfaces/IModuleFile.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleFile.cs
@@ -2,9 +2,19 @@
 
 public interface IModuleFile
 {
+    /// <summary>
+    /// Information about this file.
+    /// </summary>
     public FileInfo File { get; }
 
+    /// <summary>
+    /// Whether this file is an assembly (.dll) or not.
+    /// </summary>
     public bool IsAssembly => File.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Verify the signature for this file.
+    /// </summary>
+    /// <returns></returns>
     public bool VerifySignature();
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleInfo.cs
@@ -1,0 +1,12 @@
+﻿namespace EvoSC.Modules.Interfaces;
+
+public interface IModuleInfo
+{
+    public string Name { get; }
+    public string Title { get; }
+    public string Summary { get; }
+    public Version Version { get; }
+    public string Author { get; }
+    public IEnumerable<IModuleInfo> Dependencies { get; }
+    public bool IsInternal { get; }
+}

--- a/src/EvoSC.Modules/Interfaces/IModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleInfo.cs
@@ -2,11 +2,38 @@
 
 public interface IModuleInfo
 {
+    /// <summary>
+    /// The unique identifier name for the module.
+    /// </summary>
     public string Name { get; }
+    
+    /// <summary>
+    /// The title of the module.
+    /// </summary>
     public string Title { get; }
+    
+    /// <summary>
+    /// Short description of the module.
+    /// </summary>
     public string Summary { get; }
+    
+    /// <summary>
+    /// The module's current version.
+    /// </summary>
     public Version Version { get; }
+    
+    /// <summary>
+    /// The author of the module.
+    /// </summary>
     public string Author { get; }
+    
+    /// <summary>
+    /// Other modules that this module depends on.
+    /// </summary>
     public IEnumerable<IModuleDependency> Dependencies { get; }
+    
+    /// <summary>
+    /// Whether this module is internal or not.
+    /// </summary>
     public bool IsInternal { get; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleInfo.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleInfo.cs
@@ -7,6 +7,6 @@ public interface IModuleInfo
     public string Summary { get; }
     public Version Version { get; }
     public string Author { get; }
-    public IEnumerable<IModuleInfo> Dependencies { get; }
+    public IEnumerable<IModuleDependency> Dependencies { get; }
     public bool IsInternal { get; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
@@ -5,6 +5,7 @@ using EvoSC.Common.Interfaces.Middleware;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Middleware;
 using EvoSC.Modules.Attributes;
+using EvoSC.Modules.Interfaces;
 using SimpleInjector;
 
 namespace EvoSC.Modules;
@@ -38,7 +39,7 @@ public interface IModuleLoadContext
     /// <summary>
     /// Meta info about a module.
     /// </summary>
-    public ModuleAttribute ModuleInfo { get; init; }
+    public IModuleInfo ModuleInfo { get; init; }
     /// <summary>
     /// The module's assembly object.
     /// </summary>

--- a/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
@@ -57,4 +57,5 @@ public interface IModuleLoadContext
     /// Permissions registered from this module.
     /// </summary>
     public List<IPermission> Permissions { get; set; }
+    public List<Guid> LoadedDependencies { get; init; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
@@ -16,31 +16,45 @@ public interface IModuleLoadContext
     /// The instance of the module's main class.
     /// </summary>
     public IEvoScModule? Instance { get; init; }
+    
     /// <summary>
     /// The service container for this module.
     /// </summary>
     public Container Services { get; init; }
+    
     /// <summary>
     /// Load context for the module's assembly.
     /// </summary>
     public AssemblyLoadContext? AsmLoadContext { get; init; }
+    
     /// <summary>
     /// Unique ID of the module, used for referencing it at runtime. This ID is generated when the
     /// module is loaded.
     /// </summary>
     public Guid LoadId { get; init; }
+    
     /// <summary>
     /// The type of the module's main class.
     /// </summary>
     public Type? MainClass { get; init; }
+    
     /// <summary>
     /// Meta info about a module.
     /// </summary>
     public IModuleInfo ModuleInfo { get; init; }
+    
     /// <summary>
     /// The module's assembly object.
     /// </summary>
     public IEnumerable<Assembly> Assemblies { get; init; }
+    
+    /// <summary>
+    /// Middleware pipelines registered from this module.
+    /// </summary>
     public Dictionary<PipelineType, IActionPipeline> Pipelines { get; init; }
+    
+    /// <summary>
+    /// Permissions registered from this module.
+    /// </summary>
     public List<IPermission> Permissions { get; set; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleLoadContext.cs
@@ -1,14 +1,11 @@
 ﻿using System.Reflection;
 using System.Runtime.Loader;
-using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Middleware;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Middleware;
-using EvoSC.Modules.Attributes;
-using EvoSC.Modules.Interfaces;
 using SimpleInjector;
 
-namespace EvoSC.Modules;
+namespace EvoSC.Modules.Interfaces;
 
 /// <summary>
 /// Information about a loaded module.
@@ -26,7 +23,7 @@ public interface IModuleLoadContext
     /// <summary>
     /// Load context for the module's assembly.
     /// </summary>
-    public AssemblyLoadContext? LoadContext { get; init; }
+    public AssemblyLoadContext? AsmLoadContext { get; init; }
     /// <summary>
     /// Unique ID of the module, used for referencing it at runtime. This ID is generated when the
     /// module is loaded.
@@ -35,7 +32,7 @@ public interface IModuleLoadContext
     /// <summary>
     /// The type of the module's main class.
     /// </summary>
-    public Type? ModuleClass { get; init; }
+    public Type? MainClass { get; init; }
     /// <summary>
     /// Meta info about a module.
     /// </summary>
@@ -43,7 +40,7 @@ public interface IModuleLoadContext
     /// <summary>
     /// The module's assembly object.
     /// </summary>
-    public Assembly Assembly { get; init; }
+    public IEnumerable<Assembly> Assemblies { get; init; }
     public Dictionary<PipelineType, IActionPipeline> Pipelines { get; init; }
     public List<IPermission> Permissions { get; set; }
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleManager.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
 
-namespace EvoSC.Modules;
+namespace EvoSC.Modules.Interfaces;
 
 /// <summary>
 /// Main manager for modules, provides loading/unloading and enabling/disabling of modules.
 /// </summary>
 public interface IModuleManager
 {
-    /// <summary>
+    /* /// <summary>
     /// Load all modules from a provided assembly.
     /// </summary>
     /// <param name="assembly">The assembly which should be scanned for modules.</param>
@@ -18,5 +18,9 @@ public interface IModuleManager
     /// </summary>
     /// <param name="loadId">Load ID for the module to enable.</param>
     /// <returns></returns>
-    public Task EnableModule(Guid loadId);
+    public Task EnableModule(Guid loadId); */
+
+    public Task Load(string directory);
+    public Task Load(Assembly assembly);
+    public Task Unload(Guid loadId);
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleManager.cs
@@ -20,6 +20,8 @@ public interface IModuleManager
     /// <returns></returns>
     public Task EnableModule(Guid loadId); */
 
+    public Task EnableAsync(Guid loadId);
+    public Task DisableAsync(Guid loadId);
     public Task LoadAsync(string directory);
     public Task LoadAsync(IExternalModuleInfo moduleInfo);
     public Task LoadAsync(Assembly assembly);

--- a/src/EvoSC.Modules/Interfaces/IModuleManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleManager.cs
@@ -25,5 +25,6 @@ public interface IModuleManager
     public Task LoadAsync(string directory);
     public Task LoadAsync(IExternalModuleInfo moduleInfo);
     public Task LoadAsync(Assembly assembly);
+    public Task LoadAsync(IModuleCollection<IExternalModuleInfo> collection);
     public Task UnloadAsync(Guid loadId);
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleManager.cs
@@ -7,24 +7,53 @@ namespace EvoSC.Modules.Interfaces;
 /// </summary>
 public interface IModuleManager
 {
-    /* /// <summary>
-    /// Load all modules from a provided assembly.
-    /// </summary>
-    /// <param name="assembly">The assembly which should be scanned for modules.</param>
-    /// <returns></returns>
-    public Task LoadModulesFromAssembly(Assembly assembly);
     /// <summary>
-    /// Enable the module assigned to the specified load ID.
+    /// Enable a module.
     /// </summary>
-    /// <param name="loadId">Load ID for the module to enable.</param>
+    /// <param name="loadId">The load ID of the module to enable.</param>
     /// <returns></returns>
-    public Task EnableModule(Guid loadId); */
-
     public Task EnableAsync(Guid loadId);
+    
+    /// <summary>
+    /// Disable a module.
+    /// </summary>
+    /// <param name="loadId">The load ID of the module to disable.</param>
+    /// <returns></returns>
     public Task DisableAsync(Guid loadId);
+    
+    /// <summary>
+    /// Load an external module from a directory.
+    /// </summary>
+    /// <param name="directory">The directory containing module info and binaries.</param>
+    /// <returns></returns>
     public Task LoadAsync(string directory);
+    
+    /// <summary>
+    /// Load an external module.
+    /// </summary>
+    /// <param name="moduleInfo">Module info for the external module.</param>
+    /// <returns></returns>
     public Task LoadAsync(IExternalModuleInfo moduleInfo);
+    
+    /// <summary>
+    /// Load a module from an assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly that contains the module.</param>
+    /// <returns></returns>
     public Task LoadAsync(Assembly assembly);
+    
+    /// <summary>
+    /// Load a collection of external modules. This will load modules in the order represented
+    /// by the collection. You can use SortedModuleCollection to sort by dependencies.
+    /// </summary>
+    /// <param name="collection">The collection of modules to load.</param>
+    /// <returns></returns>
     public Task LoadAsync(IModuleCollection<IExternalModuleInfo> collection);
+    
+    /// <summary>
+    /// Unload a module. This disables and removes the module from memory.
+    /// </summary>
+    /// <param name="loadId">The load ID of the module to unload.</param>
+    /// <returns></returns>
     public Task UnloadAsync(Guid loadId);
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleManager.cs
@@ -20,7 +20,8 @@ public interface IModuleManager
     /// <returns></returns>
     public Task EnableModule(Guid loadId); */
 
-    public Task Load(string directory);
-    public Task Load(Assembly assembly);
-    public Task Unload(Guid loadId);
+    public Task LoadAsync(string directory);
+    public Task LoadAsync(IExternalModuleInfo moduleInfo);
+    public Task LoadAsync(Assembly assembly);
+    public Task UnloadAsync(Guid loadId);
 }

--- a/src/EvoSC.Modules/Interfaces/IModuleManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleManager.cs
@@ -7,6 +7,8 @@ namespace EvoSC.Modules.Interfaces;
 /// </summary>
 public interface IModuleManager
 {
+    public IReadOnlyList<IModuleLoadContext> LoadedModules { get; }
+
     /// <summary>
     /// Enable a module.
     /// </summary>

--- a/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
@@ -18,7 +18,7 @@ public interface IModuleServicesManager
     /// <summary>
     /// Create a new module service container.
     /// </summary>
-    /// <param name="moduleId">A unique GUID to identify this container with. This is typically the load ID.</param>
+    /// <param name="moduleId">The unique container GUID. This is typically the load ID.</param>
     /// <param name="assemblies">Assemblies related to the module to scan for additional services.</param>
     /// <returns></returns>
     public Container NewContainer(Guid moduleId, IEnumerable<Assembly> assemblies, List<Guid> loadedDependencies);

--- a/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
@@ -21,7 +21,7 @@ public interface IModuleServicesManager
     /// <param name="moduleId">A unique GUID to identify this container with. This is typically the load ID.</param>
     /// <param name="assemblies">Assemblies related to the module to scan for additional services.</param>
     /// <returns></returns>
-    public Container NewContainer(Guid moduleId, IEnumerable<Assembly> assemblies);
+    public Container NewContainer(Guid moduleId, IEnumerable<Assembly> assemblies, List<Guid> loadedDependencies);
     
     /// <summary>
     /// Remove a container from a module.

--- a/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
@@ -1,4 +1,5 @@
-﻿using SimpleInjector;
+﻿using System.Reflection;
+using SimpleInjector;
 
 namespace EvoSC.Modules.Interfaces;
 
@@ -13,6 +14,7 @@ public interface IModuleServicesManager
     /// <param name="moduleId">The ID of the loaded module.</param>
     /// <param name="container">The container to register for the module.</param>
     public void AddContainer(Guid moduleId, Container container);
+    public Container NewContainer(Guid moduleId, IEnumerable<Assembly> assemblies);
     /// <summary>
     /// Remove a container from a module.
     /// </summary>

--- a/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
@@ -14,7 +14,15 @@ public interface IModuleServicesManager
     /// <param name="moduleId">The ID of the loaded module.</param>
     /// <param name="container">The container to register for the module.</param>
     public void AddContainer(Guid moduleId, Container container);
+    
+    /// <summary>
+    /// Create a new module service container.
+    /// </summary>
+    /// <param name="moduleId">A unique GUID to identify this container with. This is typically the load ID.</param>
+    /// <param name="assemblies">Assemblies related to the module to scan for additional services.</param>
+    /// <returns></returns>
     public Container NewContainer(Guid moduleId, IEnumerable<Assembly> assemblies);
+    
     /// <summary>
     /// Remove a container from a module.
     /// </summary>

--- a/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
+++ b/src/EvoSC.Modules/Interfaces/IModuleServicesManager.cs
@@ -28,4 +28,12 @@ public interface IModuleServicesManager
     /// </summary>
     /// <param name="moduleId">ID of the loaded module.</param>
     public void RemoveContainer(Guid moduleId);
+    
+    /// <summary>
+    /// Register a service dependency for a module. This allows a module to inject
+    /// services from the specified dependency.
+    /// </summary>
+    /// <param name="moduleId">The ID of the module that requires the dependency.</param>
+    /// <param name="dependencyId">The ID of the dependency.</param>
+    public void RegisterDependency(Guid moduleId, Guid dependencyId);
 }

--- a/src/EvoSC.Modules/Interfaces/IToggleable.cs
+++ b/src/EvoSC.Modules/Interfaces/IToggleable.cs
@@ -10,6 +10,7 @@ public interface IToggleable
     /// </summary>
     /// <returns></returns>
     public Task Enable();
+    
     /// <summary>
     /// Disable the module.
     /// </summary>

--- a/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
@@ -10,6 +10,5 @@ public class ExternalModuleInfo : IExternalModuleInfo
     public required Version Version { get; init; }
     public required string Author { get; init; }
     public required IEnumerable<IModuleInfo> Dependencies { get; init; }
-    public required bool IsInternal { get; init; }
     public required DirectoryInfo Directory { get; init; }
 }

--- a/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
@@ -1,0 +1,15 @@
+﻿using EvoSC.Modules.Interfaces;
+
+namespace EvoSC.Modules.Models;
+
+public class ExternalModuleInfo : IExternalModuleInfo
+{
+    public required string Name { get; init; }
+    public required string Title { get; init; }
+    public required string Summary { get; init; }
+    public required Version Version { get; init; }
+    public required string Author { get; init; }
+    public required IEnumerable<IModuleInfo> Dependencies { get; init; }
+    public required bool IsInternal { get; init; }
+    public required DirectoryInfo Directory { get; init; }
+}

--- a/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
@@ -11,4 +11,5 @@ public class ExternalModuleInfo : IExternalModuleInfo
     public required string Author { get; init; }
     public required IEnumerable<IModuleInfo> Dependencies { get; init; }
     public required DirectoryInfo Directory { get; init; }
+    public required IEnumerable<IModuleFile> ModuleFiles { get; init; }
 }

--- a/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/ExternalModuleInfo.cs
@@ -9,7 +9,7 @@ public class ExternalModuleInfo : IExternalModuleInfo
     public required string Summary { get; init; }
     public required Version Version { get; init; }
     public required string Author { get; init; }
-    public required IEnumerable<IModuleInfo> Dependencies { get; init; }
+    public required IEnumerable<IModuleDependency> Dependencies { get; init; }
     public required DirectoryInfo Directory { get; init; }
     public required IEnumerable<IModuleFile> ModuleFiles { get; init; }
 }

--- a/src/EvoSC.Modules/Models/InternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/InternalModuleInfo.cs
@@ -1,4 +1,5 @@
-﻿using EvoSC.Modules.Interfaces;
+﻿using System.Reflection;
+using EvoSC.Modules.Interfaces;
 
 namespace EvoSC.Modules.Models;
 
@@ -9,5 +10,6 @@ public class InternalModuleInfo : IInternalModuleInfo
     public required string Summary { get; init; }
     public required Version Version { get; init; }
     public required string Author { get; init; }
-    public IEnumerable<IModuleDependency> Dependencies { get; init; }
+    public required IEnumerable<IModuleDependency> Dependencies { get; init; }
+    public required Assembly Assembly { get; init; }
 }

--- a/src/EvoSC.Modules/Models/InternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/InternalModuleInfo.cs
@@ -9,5 +9,5 @@ public class InternalModuleInfo : IInternalModuleInfo
     public required string Summary { get; init; }
     public required Version Version { get; init; }
     public required string Author { get; init; }
-    public IEnumerable<IModuleInfo> Dependencies { get; init; }
+    public IEnumerable<IModuleDependency> Dependencies { get; init; }
 }

--- a/src/EvoSC.Modules/Models/InternalModuleInfo.cs
+++ b/src/EvoSC.Modules/Models/InternalModuleInfo.cs
@@ -1,0 +1,13 @@
+﻿using EvoSC.Modules.Interfaces;
+
+namespace EvoSC.Modules.Models;
+
+public class InternalModuleInfo : IInternalModuleInfo
+{
+    public required string Name { get; init; }
+    public required string Title { get; init; }
+    public required string Summary { get; init; }
+    public required Version Version { get; init; }
+    public required string Author { get; init; }
+    public IEnumerable<IModuleInfo> Dependencies { get; init; }
+}

--- a/src/EvoSC.Modules/Models/ModuleDependency.cs
+++ b/src/EvoSC.Modules/Models/ModuleDependency.cs
@@ -1,0 +1,9 @@
+﻿using EvoSC.Modules.Interfaces;
+
+namespace EvoSC.Modules.Models;
+
+public class ModuleDependency : IModuleDependency
+{
+    public required string Name { get; init; }
+    public required Version Version { get; init; }
+}

--- a/src/EvoSC.Modules/Models/ModuleFile.cs
+++ b/src/EvoSC.Modules/Models/ModuleFile.cs
@@ -1,0 +1,20 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using EvoSC.Modules.Interfaces;
+
+namespace EvoSC.Modules.Models;
+
+public class ModuleFile : IModuleFile
+{
+    public FileInfo File { get; init; }
+
+    public ModuleFile(FileInfo file)
+    {
+        File = file;
+    }
+    
+    public bool VerifySignature()
+    {
+        // todo: github #35 https://github.com/EvoTM/EvoSC-sharp/issues/35
+        return true;
+    }
+}

--- a/src/EvoSC.Modules/Models/ModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Models/ModuleLoadContext.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
 using System.Runtime.Loader;
-using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Middleware;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Middleware;
 using EvoSC.Modules.Attributes;
+using EvoSC.Modules.Interfaces;
 using SimpleInjector;
 
-namespace EvoSC.Modules.Info;
+namespace EvoSC.Modules.Models;
 
 public class ModuleLoadContext : IModuleLoadContext
 {
@@ -16,7 +16,7 @@ public class ModuleLoadContext : IModuleLoadContext
     public AssemblyLoadContext? LoadContext { get; init; }
     public Guid LoadId { get; init; }
     public Type? ModuleClass { get; init; }
-    public ModuleAttribute ModuleInfo { get; init; }
+    public IModuleInfo ModuleInfo { get; init; }
     public Assembly Assembly { get; init; }
     public Dictionary<PipelineType, IActionPipeline> Pipelines { get; init; }
     public List<IPermission> Permissions { get; set; }

--- a/src/EvoSC.Modules/Models/ModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Models/ModuleLoadContext.cs
@@ -11,13 +11,13 @@ namespace EvoSC.Modules.Models;
 
 public class ModuleLoadContext : IModuleLoadContext
 {
-    public IEvoScModule? Instance { get; init; }
-    public Container Services { get; init; }
-    public AssemblyLoadContext? LoadContext { get; init; }
-    public Guid LoadId { get; init; }
-    public Type? ModuleClass { get; init; }
-    public IModuleInfo ModuleInfo { get; init; }
-    public Assembly Assembly { get; init; }
-    public Dictionary<PipelineType, IActionPipeline> Pipelines { get; init; }
-    public List<IPermission> Permissions { get; set; }
+    public required IEvoScModule? Instance { get; init; }
+    public required Container Services { get; init; }
+    public required AssemblyLoadContext? AsmLoadContext { get; init; }
+    public required Guid LoadId { get; init; }
+    public required Type? MainClass { get; init; }
+    public required IModuleInfo ModuleInfo { get; init; }
+    public required IEnumerable<Assembly> Assemblies { get; init; }
+    public required Dictionary<PipelineType, IActionPipeline> Pipelines { get; init; }
+    public required List<IPermission> Permissions { get; set; }
 }

--- a/src/EvoSC.Modules/Models/ModuleLoadContext.cs
+++ b/src/EvoSC.Modules/Models/ModuleLoadContext.cs
@@ -20,4 +20,5 @@ public class ModuleLoadContext : IModuleLoadContext
     public required IEnumerable<Assembly> Assemblies { get; init; }
     public required Dictionary<PipelineType, IActionPipeline> Pipelines { get; init; }
     public required List<IPermission> Permissions { get; set; }
+    public required List<Guid> LoadedDependencies { get; init; }
 }

--- a/src/EvoSC.Modules/ModuleManager.cs
+++ b/src/EvoSC.Modules/ModuleManager.cs
@@ -330,7 +330,10 @@ public class ModuleManager : IModuleManager
     private async Task<IModuleLoadContext> CreateModuleLoadContextAsync(Guid loadId, Type mainClass, AssemblyLoadContext? asmLoadContext, IModuleInfo moduleInfo)
     {
         var assemblies = asmLoadContext?.Assemblies ?? new[] {mainClass.Assembly};
+        
         var moduleServices = _servicesManager.NewContainer(loadId, assemblies);
+        moduleServices.RegisterInstance(moduleInfo);
+        
         await RegisterModuleConfigAsync(assemblies, moduleServices, moduleInfo);
         var moduleInstance = CreateModuleInstance(mainClass, moduleServices);
 

--- a/src/EvoSC.Modules/ModuleManager.cs
+++ b/src/EvoSC.Modules/ModuleManager.cs
@@ -74,17 +74,6 @@ public class ModuleManager : IModuleManager
         
         _logger.LogDebug("Module {Type}({Module}) was enabled", moduleContext.MainClass, loadId);
     }
-    
-    private async Task EnableModuleAsync(Guid loadId)
-    {
-        var moduleContext = GetModuleById(loadId);
-
-        await EnableControllers(moduleContext);
-        await EnableMiddlewares(moduleContext);
-        await TryCallModuleEnable(moduleContext);
-        
-        _logger.LogDebug("Module {Type}({Module}) was installed", moduleContext.MainClass, loadId);
-    }
 
     private IModuleLoadContext GetModuleById(Guid loadId)
     {
@@ -389,9 +378,25 @@ public class ModuleManager : IModuleManager
         _logger.LogDebug("External Module '{Name}' loaded with ID: {LoadId}", moduleInfo.Name, loadId);
 
         await InstallModuleAsync(loadId);
-        await EnableModuleAsync(loadId);
+        await EnableAsync(loadId);
     }
-    
+
+    public async Task EnableAsync(Guid loadId)
+    {
+        var moduleContext = GetModuleById(loadId);
+
+        await EnableControllers(moduleContext);
+        await EnableMiddlewares(moduleContext);
+        await TryCallModuleEnable(moduleContext);
+        
+        _logger.LogDebug("Module {Type}({Module}) was installed", moduleContext.MainClass, loadId);
+    }
+
+    public Task DisableAsync(Guid loadId)
+    {
+        throw new NotImplementedException();
+    }
+
     public Task LoadAsync(string directory)
     {
         if (!Directory.Exists(directory))

--- a/src/EvoSC.Modules/ModuleManager.cs
+++ b/src/EvoSC.Modules/ModuleManager.cs
@@ -221,48 +221,6 @@ public class ModuleManager : IModuleManager
         return Task.CompletedTask;
     }
 
-    private Container CreateServiceContainer(Assembly assembly)
-    {
-        var container = new Container();
-        container.Options.EnableAutoVerification = false;
-        container.Options.SuppressLifestyleMismatchVerification = true;
-        container.Options.UseStrictLifestyleMismatchBehavior = false;
-
-        foreach (var module in assembly.Modules)
-        {
-            foreach (var type in module.GetTypes())
-            {
-                var serviceAttr = type.GetCustomAttribute<ServiceAttribute>();
-
-                if (serviceAttr == null)
-                {
-                    continue;
-                }
-
-                var intf = type.GetInterfaces().FirstOrDefault();
-
-                if (intf == null)
-                {
-                    throw new ModuleServicesException($"Service {type} must implement a custom interface.");
-                }
-
-                switch (serviceAttr.LifeStyle)
-                {
-                    case ServiceLifeStyle.Singleton:
-                        container.RegisterSingleton(intf, type);
-                        break;
-                    case ServiceLifeStyle.Transient:
-                        container.Register(intf, type);
-                        break;
-                    default:
-                        throw new ModuleServicesException($"Unsupported lifetime type for module service: {type}");
-                }
-            }
-        }
-
-        return container;
-    }
-
     private async Task RegisterModuleConfigAsync(IEnumerable<Assembly> assemblies, Container container, IModuleInfo moduleInfo)
     {
         foreach (var assembly in assemblies)

--- a/src/EvoSC.Modules/ModuleServicesManager.cs
+++ b/src/EvoSC.Modules/ModuleServicesManager.cs
@@ -37,7 +37,7 @@ public class ModuleServicesManager : IModuleServicesManager
         _moduleContainers.Add(moduleId, container);
     }
 
-    public void AddDependency(Guid moduleId, Guid dependencyId)
+    public void RegisterDependency(Guid moduleId, Guid dependencyId)
     {
         if (!_moduleContainers.ContainsKey(moduleId))
         {
@@ -103,7 +103,7 @@ public class ModuleServicesManager : IModuleServicesManager
         
         foreach (var dependency in loadedDependencies)
         {
-            AddDependency(moduleId, dependency);
+            RegisterDependency(moduleId, dependency);
         }
         
         return container;

--- a/src/EvoSC.Modules/Util/ModuleDirectoryUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleDirectoryUtils.cs
@@ -1,0 +1,26 @@
+﻿using EvoSC.Modules.Interfaces;
+
+namespace EvoSC.Modules.Util;
+
+public static class ModuleDirectoryUtils
+{
+    public static SortedModuleCollection<IExternalModuleInfo> FindModulesFromDirectory(string directory)
+    {
+        var modules = new SortedModuleCollection<IExternalModuleInfo>();
+        
+        foreach (var dir in Directory.GetDirectories(Path.GetFullPath(directory)))
+        {
+            var infoFile = Path.Combine(dir, "info.toml");
+
+            if (!File.Exists(infoFile))
+            {
+                continue;
+            }
+
+            var moduleInfo = ModuleInfoUtils.CreateFromDirectory(new DirectoryInfo(dir));
+            modules.Add(moduleInfo);
+        }
+
+        return modules;
+    }
+}

--- a/src/EvoSC.Modules/Util/ModuleDirectoryUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleDirectoryUtils.cs
@@ -12,7 +12,18 @@ public static class ModuleDirectoryUtils
     public static SortedModuleCollection<IExternalModuleInfo> FindModulesFromDirectory(string directory)
     {
         var modules = new SortedModuleCollection<IExternalModuleInfo>();
-        
+        FindModulesFromDirectory(directory, modules);
+        return modules;
+    }
+
+    /// <summary>
+    /// Find all modules within a given directory and add them to an existing collection.
+    /// </summary>
+    /// <param name="directory">A directory containing module directories.</param>
+    /// <param name="modules">Collection to add the modules to.</param>
+    /// <returns></returns>
+    public static void FindModulesFromDirectory(string directory, SortedModuleCollection<IExternalModuleInfo> modules)
+    {
         foreach (var dir in Directory.GetDirectories(Path.GetFullPath(directory)))
         {
             var infoFile = Path.Combine(dir, "info.toml");
@@ -25,7 +36,5 @@ public static class ModuleDirectoryUtils
             var moduleInfo = ModuleInfoUtils.CreateFromDirectory(new DirectoryInfo(dir));
             modules.Add(moduleInfo);
         }
-
-        return modules;
     }
 }

--- a/src/EvoSC.Modules/Util/ModuleDirectoryUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleDirectoryUtils.cs
@@ -4,6 +4,11 @@ namespace EvoSC.Modules.Util;
 
 public static class ModuleDirectoryUtils
 {
+    /// <summary>
+    /// Find all modules within a given directory.
+    /// </summary>
+    /// <param name="directory">A directory containing module directories.</param>
+    /// <returns></returns>
     public static SortedModuleCollection<IExternalModuleInfo> FindModulesFromDirectory(string directory)
     {
         var modules = new SortedModuleCollection<IExternalModuleInfo>();

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -48,7 +48,7 @@ public static class ModuleInfoUtils
     /// <summary>
     /// Create an external module info object from a module directory.
     /// </summary>
-    /// <param name="dir">THe directory containing the module info file.</param>
+    /// <param name="dir">The directory containing the module info file.</param>
     /// <returns></returns>
     /// <exception cref="FileNotFoundException">When the info file was not found.</exception>
     /// <exception cref="InvalidOperationException">When the info file has an invalid format.</exception>

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -19,6 +19,11 @@ public static class ModuleInfoUtils
         return value;
     }
     
+    /// <summary>
+    /// Create an internal module info object from an assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly containing a module.</param>
+    /// <returns></returns>
     public static IInternalModuleInfo CreateFromAssembly(Assembly assembly)
     {
         var name = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleIdentifierAttribute>()?.Name, "Name");
@@ -40,6 +45,13 @@ public static class ModuleInfoUtils
         };
     }
 
+    /// <summary>
+    /// Create an external module info object from a module directory.
+    /// </summary>
+    /// <param name="dir">THe directory containing the module info file.</param>
+    /// <returns></returns>
+    /// <exception cref="FileNotFoundException">When the info file was not found.</exception>
+    /// <exception cref="InvalidOperationException">When the info file has an invalid format.</exception>
     public static IExternalModuleInfo CreateFromDirectory(DirectoryInfo dir)
     {
         var path = Path.Combine(dir.FullName, "info.toml");
@@ -60,11 +72,6 @@ public static class ModuleInfoUtils
         if (!Version.TryParse(versionString, out var version))
         {
             throw new InvalidOperationException($"Module version is in an invalid format. Cannot parse it in: {path}");
-        }
-
-        if (infoDocument.ContainsKey("dependencies"))
-        {
-            
         }
 
         var dependencies = Array.Empty<IModuleDependency>().AsEnumerable();

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -51,7 +51,7 @@ public static class ModuleInfoUtils
     /// <param name="dir">The directory containing the module info file.</param>
     /// <returns></returns>
     /// <exception cref="FileNotFoundException">Thrown when the info file was not found.</exception>
-    /// <exception cref="InvalidOperationException">When the info file has an invalid format.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the info file has an invalid format.</exception>
     public static IExternalModuleInfo CreateFromDirectory(DirectoryInfo dir)
     {
         var path = Path.Combine(dir.FullName, "info.toml");

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -26,7 +26,7 @@ public static class ModuleInfoUtils
         var summary = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleSummaryAttribute>()?.Summary, "Summary");
         var version = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleVersionAttribute>()?.Version, "Version");
         var author = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleAuthorAttribute>()?.Author, "Author");
-        var dependencies = Array.Empty<IModuleInfo>();
+        var dependencies = Array.Empty<IModuleDependency>();
 
         return new InternalModuleInfo
         {
@@ -60,8 +60,12 @@ public static class ModuleInfoUtils
         {
             throw new InvalidOperationException($"Module version is in an invalid format. Cannot parse it in: {path}");
         }
-        
-        var dependencies = Array.Empty<IModuleInfo>();
+
+        var dependencyTable = ValidateModuleProperty(infoDocument.GetSubTable("dependencies").Entries, "Dependencies");
+        var dependencies = dependencyTable.Select(d => new ModuleDependency
+        {
+            Name = d.Key, Version = Version.Parse(d.Value.StringValue)
+        });
 
         var moduleFiles = dir
             .GetFiles("*", SearchOption.AllDirectories)

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -52,21 +52,31 @@ public static class ModuleInfoUtils
         var infoDocument = TomlParser.ParseFile(path);
 
         var name = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Name");
-        var title = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Title");
-        var summary = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Summary");
-        var versionString = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Version");
-        var author = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Author");
+        var title = ValidateModuleProperty(infoDocument.GetValue("info.title")?.StringValue, "Title");
+        var summary = ValidateModuleProperty(infoDocument.GetValue("info.summary")?.StringValue, "Summary");
+        var versionString = ValidateModuleProperty(infoDocument.GetValue("info.version")?.StringValue, "Version");
+        var author = ValidateModuleProperty(infoDocument.GetValue("info.author")?.StringValue, "Author");
         
         if (!Version.TryParse(versionString, out var version))
         {
             throw new InvalidOperationException($"Module version is in an invalid format. Cannot parse it in: {path}");
         }
 
-        var dependencyTable = ValidateModuleProperty(infoDocument.GetSubTable("dependencies").Entries, "Dependencies");
-        var dependencies = dependencyTable.Select(d => new ModuleDependency
+        if (infoDocument.ContainsKey("dependencies"))
         {
-            Name = d.Key, Version = Version.Parse(d.Value.StringValue)
-        });
+            
+        }
+
+        var dependencies = Array.Empty<IModuleDependency>().AsEnumerable();
+
+        if (infoDocument.ContainsKey("dependencies"))
+        {
+            var dependencyTable = ValidateModuleProperty(infoDocument.GetSubTable("dependencies").Entries, "Dependencies");
+            dependencies = dependencyTable.Select(d => new ModuleDependency
+            {
+                Name = d.Key, Version = Version.Parse(d.Value.StringValue)
+            });
+        }
 
         var moduleFiles = dir
             .GetFiles("*", SearchOption.AllDirectories)

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -9,7 +9,7 @@ namespace EvoSC.Modules.Util;
 
 public static class ModuleInfoUtils
 {
-    private static T ValidateModuleProperty<T>(T? value, string name)
+    private static T ValidateModuleProperty<T>(T? value, string name) where T : class
     {
         if (value == null)
         {

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -71,7 +71,7 @@ public static class ModuleInfoUtils
         
         if (!Version.TryParse(versionString, out var version))
         {
-            throw new InvalidOperationException($"Module version is in an invalid format. Cannot parse it in: {path}");
+            throw new InvalidOperationException($"Module version format is invalid. Cannot parse it in: {path}");
         }
 
         var dependencies = Array.Empty<IModuleDependency>().AsEnumerable();

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -1,0 +1,82 @@
+﻿using System.Reflection;
+using EvoSC.Modules.Attributes;
+using EvoSC.Modules.Exceptions;
+using EvoSC.Modules.Interfaces;
+using EvoSC.Modules.Models;
+using Tomlet;
+
+namespace EvoSC.Modules.Util;
+
+public static class ModuleInfoUtils
+{
+    private static T ValidateModuleProperty<T>(T? value, string name)
+    {
+        if (value == null)
+        {
+            throw new MissingModulePropertyException(name);
+        }
+
+        return value;
+    }
+    
+    public static IInternalModuleInfo CreateFromAssembly(Assembly assembly)
+    {
+        var name = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleIdentifierAttribute>()?.Name, "Name");
+        var title = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleTitleAttribute>()?.Title, "Title");
+        var summary = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleSummaryAttribute>()?.Summary, "Summary");
+        var version = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleVersionAttribute>()?.Version, "Version");
+        var author = ValidateModuleProperty(assembly.GetCustomAttribute<ModuleAuthorAttribute>()?.Author, "Author");
+        var dependencies = Array.Empty<IModuleInfo>();
+
+        return new InternalModuleInfo
+        {
+            Name = name!,
+            Title = title!,
+            Summary = summary!,
+            Version = version!,
+            Author = author!,
+            Dependencies = dependencies
+        };
+    }
+
+    public static IExternalModuleInfo CreateFromDirectory(DirectoryInfo dir)
+    {
+        var path = Path.Combine(dir.FullName, "info.toml");
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Failed to find the module's info file (info.toml) at: {path}");
+        }
+
+        var infoDocument = TomlParser.ParseFile(path);
+
+        var name = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Name");
+        var title = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Title");
+        var summary = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Summary");
+        var versionString = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Version");
+        var author = ValidateModuleProperty(infoDocument.GetValue("info.name")?.StringValue, "Author");
+        
+        if (!Version.TryParse(versionString, out var version))
+        {
+            throw new InvalidOperationException($"Module version is in an invalid format. Cannot parse it in: {path}");
+        }
+        
+        var dependencies = Array.Empty<IModuleInfo>();
+
+        var moduleFiles = dir
+            .GetFiles("*", SearchOption.AllDirectories)
+            .Select(file => new ModuleFile(file));
+
+        return new ExternalModuleInfo
+        {
+            Name = name,
+            Title = title,
+            Summary = summary,
+            Version = version,
+            Author = author,
+            Dependencies = dependencies,
+            Directory = dir,
+            ModuleFiles = moduleFiles
+        };
+    }
+}

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -35,7 +35,8 @@ public static class ModuleInfoUtils
             Summary = summary!,
             Version = version!,
             Author = author!,
-            Dependencies = dependencies
+            Dependencies = dependencies,
+            Assembly = assembly
         };
     }
 

--- a/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
+++ b/src/EvoSC.Modules/Util/ModuleInfoUtils.cs
@@ -50,7 +50,7 @@ public static class ModuleInfoUtils
     /// </summary>
     /// <param name="dir">The directory containing the module info file.</param>
     /// <returns></returns>
-    /// <exception cref="FileNotFoundException">When the info file was not found.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the info file was not found.</exception>
     /// <exception cref="InvalidOperationException">When the info file has an invalid format.</exception>
     public static IExternalModuleInfo CreateFromDirectory(DirectoryInfo dir)
     {

--- a/src/EvoSC.Modules/Util/SortedModuleCollection.cs
+++ b/src/EvoSC.Modules/Util/SortedModuleCollection.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections;
+using EvoSC.Modules.Exceptions.ModuleDependency;
+using EvoSC.Modules.Interfaces;
+using DependencyGraph = System.Collections.Generic.Dictionary<string, System.Collections.Generic.IList<string>>;
+
+namespace EvoSC.Modules.Util;
+
+public class SortedModuleCollection<T> : IModuleCollection<T> where T : IModuleInfo
+{
+    private readonly Dictionary<string, T> _modules = new();
+
+    /// <summary>
+    /// Get a list of modules sorted by their dependencies.
+    /// Complexity: O(n+m)
+    /// </summary>
+    public IEnumerable<T> SortedModules => GetSortedModules();
+
+    public void Add(T module)
+    {
+        _modules[module.Name] = module;
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        return GetSortedModules().GetEnumerator();
+    }
+    
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    private List<T> GetSortedModules()
+    {
+        var dependencyGraph = MakeDependencyGraph();
+        EnsureDependenciesExists(dependencyGraph);
+        
+        var sortedDependencies = new List<T>();
+
+        while (true)
+        {
+            string? selected = null;
+
+            foreach (var dependent in dependencyGraph)
+            {
+                if (dependent.Value.Count != 0)
+                {
+                    continue;
+                }
+
+                sortedDependencies.Add(_modules[dependent.Key]);
+                RemoveDependent(dependencyGraph, dependent);
+
+                selected = dependent.Key;
+                break;
+            }
+
+            if (selected != null)
+            {
+                dependencyGraph.Remove(selected);
+            }
+            else
+            {
+                break;
+            }
+        }
+        
+        DetectCycle(dependencyGraph);
+        return sortedDependencies;
+    }
+
+    private static void RemoveDependent(DependencyGraph dependencyGraph, KeyValuePair<string, IList<string>> dependent)
+    {
+        foreach (var dependencies in dependencyGraph)
+        {
+            if (dependencies.Value.Contains(dependencies.Key))
+            {
+                dependencies.Value.Remove(dependent.Key);
+            }
+        }
+    }
+
+    private DependencyGraph MakeDependencyGraph()
+    {
+        var adjList = new Dictionary<string, IList<string>>();
+
+        foreach (var module in _modules.Values)
+        {
+            adjList.Add(module.Name, new List<string>());
+
+            foreach (var dependency in module.Dependencies)
+            {
+                adjList[module.Name].Add(dependency.Name);
+            }
+        }
+
+        return adjList;
+    }
+    
+    private void EnsureDependenciesExists(DependencyGraph moduleDependencies)
+    {
+        foreach (var (dependent, dependencies) in moduleDependencies)
+        {
+            foreach (var dependency in dependencies)
+            {
+                if (!_modules.ContainsKey(dependency))
+                {
+                    throw new DependencyNotFoundException(dependent, dependency);
+                }
+            }
+        }
+    }
+
+    private void DetectCycle(DependencyGraph dependencies)
+    {
+        if (dependencies.Count > 0)
+        {
+            throw new DependencyCycleException(dependencies);
+        }
+    }
+}

--- a/src/EvoSC.Modules/Util/SortedModuleCollection.cs
+++ b/src/EvoSC.Modules/Util/SortedModuleCollection.cs
@@ -8,6 +8,7 @@ namespace EvoSC.Modules.Util;
 public class SortedModuleCollection<T> : IModuleCollection<T> where T : IModuleInfo
 {
     private readonly Dictionary<string, T> _modules = new();
+    private readonly List<string> _ignoredDependencies = new();
 
     /// <summary>
     /// Get a list of modules sorted by their dependencies.
@@ -90,6 +91,11 @@ public class SortedModuleCollection<T> : IModuleCollection<T> where T : IModuleI
 
             foreach (var dependency in module.Dependencies)
             {
+                if (_ignoredDependencies.Contains(dependency.Name))
+                {
+                    continue;
+                }
+                
                 adjList[module.Name].Add(dependency.Name);
             }
         }
@@ -103,7 +109,7 @@ public class SortedModuleCollection<T> : IModuleCollection<T> where T : IModuleI
         {
             foreach (var dependency in dependencies)
             {
-                if (!_modules.ContainsKey(dependency))
+                if (!_modules.ContainsKey(dependency) && !_ignoredDependencies.Contains(dependency))
                 {
                     throw new DependencyNotFoundException(dependent, dependency);
                 }
@@ -117,5 +123,10 @@ public class SortedModuleCollection<T> : IModuleCollection<T> where T : IModuleI
         {
             throw new DependencyCycleException(dependencies);
         }
+    }
+
+    public void SetIgnoredDependencies(IEnumerable<string> ignoredDependencies)
+    {
+        _ignoredDependencies.AddRange(ignoredDependencies);
     }
 }

--- a/src/EvoSC/Application.cs
+++ b/src/EvoSC/Application.cs
@@ -20,6 +20,7 @@ using EvoSC.Common.Remote;
 using EvoSC.Common.Services;
 using EvoSC.Modules;
 using EvoSC.Modules.Extensions;
+using EvoSC.Modules.Interfaces;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using Microsoft.Extensions.DependencyInjection;
@@ -143,7 +144,6 @@ public class Application : IEvoSCApplication
         var modules = _services.GetInstance<IModuleManager>();
 
         await modules.LoadInternalModules();
-        await modules.LoadExternalModules();
     }
 
     private async Task StartBackgroundServices()

--- a/src/EvoSC/Application.cs
+++ b/src/EvoSC/Application.cs
@@ -143,6 +143,7 @@ public class Application : IEvoSCApplication
         var modules = _services.GetInstance<IModuleManager>();
 
         await modules.LoadInternalModules();
+        await modules.LoadExternalModules();
     }
 
     private async Task StartBackgroundServices()

--- a/src/EvoSC/Application.cs
+++ b/src/EvoSC/Application.cs
@@ -21,6 +21,7 @@ using EvoSC.Common.Services;
 using EvoSC.Modules;
 using EvoSC.Modules.Extensions;
 using EvoSC.Modules.Interfaces;
+using EvoSC.Modules.Util;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using Microsoft.Extensions.DependencyInjection;
@@ -142,8 +143,22 @@ public class Application : IEvoSCApplication
     private async Task SetupModules()
     {
         var modules = _services.GetInstance<IModuleManager>();
+        var config = _services.GetInstance<IEvoScBaseConfig>();
 
         await modules.LoadInternalModules();
+
+        var dirs = config.Modules.ModuleDirectories;
+        
+        foreach (var dir in dirs)
+        {
+            if (!Directory.Exists(dir))
+            {
+                continue;
+            }
+            
+            var externalModules = ModuleDirectoryUtils.FindModulesFromDirectory(dir);
+            await modules.LoadAsync(externalModules);
+        }
     }
 
     private async Task StartBackgroundServices()

--- a/src/EvoSC/Application.cs
+++ b/src/EvoSC/Application.cs
@@ -148,17 +148,19 @@ public class Application : IEvoSCApplication
         await modules.LoadInternalModules();
 
         var dirs = config.Modules.ModuleDirectories;
-        
+        var externalModules = new SortedModuleCollection<IExternalModuleInfo>();
         foreach (var dir in dirs)
         {
             if (!Directory.Exists(dir))
             {
                 continue;
             }
-            
-            var externalModules = ModuleDirectoryUtils.FindModulesFromDirectory(dir);
-            await modules.LoadAsync(externalModules);
+
+            ModuleDirectoryUtils.FindModulesFromDirectory(dir, externalModules);
         }
+
+        externalModules.SetIgnoredDependencies(modules.LoadedModules.Select(m => m.ModuleInfo.Name));
+        await modules.LoadAsync(externalModules);
     }
 
     private async Task StartBackgroundServices()

--- a/src/EvoSC/InternalModules.cs
+++ b/src/EvoSC/InternalModules.cs
@@ -1,5 +1,6 @@
 ﻿using EvoSC.Common.Interfaces;
 using EvoSC.Modules;
+using EvoSC.Modules.Interfaces;
 using EvoSC.Modules.Official.ExampleModule;
 using EvoSC.Modules.Official.Player;
 using FluentMigrator.Runner.Exceptions;
@@ -42,15 +43,7 @@ public static class InternalModules
     {
         foreach (var module in Modules)
         {
-            await modules.LoadModulesFromAssembly(module.Assembly);
-        }
-    }
-
-    public static async Task LoadExternalModules(this IModuleManager modules)
-    {
-        foreach (var module in Directory.GetFiles("modules/"))
-        {
-            
+            await modules.Load(module.Assembly);
         }
     }
 }

--- a/src/EvoSC/InternalModules.cs
+++ b/src/EvoSC/InternalModules.cs
@@ -45,4 +45,12 @@ public static class InternalModules
             await modules.LoadModulesFromAssembly(module.Assembly);
         }
     }
+
+    public static async Task LoadExternalModules(this IModuleManager modules)
+    {
+        foreach (var module in Directory.GetFiles("modules/"))
+        {
+            
+        }
+    }
 }

--- a/src/EvoSC/InternalModules.cs
+++ b/src/EvoSC/InternalModules.cs
@@ -43,7 +43,7 @@ public static class InternalModules
     {
         foreach (var module in Modules)
         {
-            await modules.Load(module.Assembly);
+            await modules.LoadAsync(module.Assembly);
         }
     }
 }

--- a/src/Modules/ExampleModule/ExampleController.cs
+++ b/src/Modules/ExampleModule/ExampleController.cs
@@ -1,4 +1,5 @@
-﻿using EvoSC.Commands.Attributes;
+﻿using System.Threading.Tasks;
+using EvoSC.Commands.Attributes;
 using EvoSC.Commands.Interfaces;
 using EvoSC.Common.Controllers;
 using EvoSC.Common.Controllers.Attributes;

--- a/src/Modules/ExampleModule/ExampleController2.cs
+++ b/src/Modules/ExampleModule/ExampleController2.cs
@@ -1,0 +1,33 @@
+﻿using EvoSC.Commands;
+using EvoSC.Commands.Attributes;
+using EvoSC.Common.Controllers;
+using EvoSC.Common.Controllers.Attributes;
+using EvoSC.Modules.Interfaces;
+
+namespace EvoSC.Modules.Official.ExampleModule;
+
+[Controller]
+public class ExampleController2 : EvoScController<CommandInteractionContext>
+{
+    private readonly IModuleManager _modules;
+    
+    public ExampleController2(IModuleManager modules)
+    {
+        _modules = modules;
+    }
+
+    [ChatCommand("module", "Manage a module")]
+    public async Task ManageModule(string action, string loadIdStr)
+    {
+        var loadId = Guid.Parse(loadIdStr);
+
+        if (action == "enable")
+        {
+            await _modules.EnableAsync(loadId);
+        }
+        else if (action == "disable")
+        {
+            await _modules.DisableAsync(loadId);
+        }
+    }
+}

--- a/src/Modules/ExampleModule/ExampleModule.cs
+++ b/src/Modules/ExampleModule/ExampleModule.cs
@@ -1,4 +1,5 @@
-﻿using EvoSC.Common.Interfaces.Middleware;
+﻿using System.Threading.Tasks;
+using EvoSC.Common.Interfaces.Middleware;
 using EvoSC.Common.Interfaces.Services;
 using EvoSC.Modules.Attributes;
 using Microsoft.Extensions.Logging;

--- a/src/Modules/ExampleModule/ExampleModule.cs
+++ b/src/Modules/ExampleModule/ExampleModule.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace EvoSC.Modules.Official.ExampleModule;
 
-[Module(Name = "ExampleModule", Description = "An example module to get people started.", IsInternal = true)]
+[Module(IsInternal = true)]
 public class ExampleModule : EvoScModule, IToggleable
 {
     public Task Enable()

--- a/src/Modules/ExampleModule/ExampleModule.cs
+++ b/src/Modules/ExampleModule/ExampleModule.cs
@@ -6,6 +6,15 @@ using Microsoft.Extensions.Logging;
 namespace EvoSC.Modules.Official.ExampleModule;
 
 [Module(Name = "ExampleModule", Description = "An example module to get people started.", IsInternal = true)]
-public class ExampleModule : EvoScModule
+public class ExampleModule : EvoScModule, IToggleable
 {
+    public Task Enable()
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task Disable()
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/src/Modules/ExampleModule/ExampleModule.csproj
+++ b/src/Modules/ExampleModule/ExampleModule.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\EvoSC.Modules\EvoSC.Modules.csproj" />
+        <ProjectReference Include="..\..\EvoSC.Modules.SourceGeneration\EvoSC.Modules.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\EvoSC.Modules\EvoSC.Modules.csproj" />
     </ItemGroup>
-
 </Project>

--- a/src/Modules/ExampleModule/Info.cs
+++ b/src/Modules/ExampleModule/Info.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using EvoSC.Modules.Attributes;
+
+[assembly: ModuleIdentifier("ExampleModule")]
+[assembly: ModuleTitle("Example Module")]
+[assembly: ModuleSummary("An example module to get people started.")]
+[assembly: ModuleVersion("1.0.0")]
+[assembly: ModuleAuthor("snixtho")]

--- a/src/Modules/ExampleModule/Info.cs
+++ b/src/Modules/ExampleModule/Info.cs
@@ -1,8 +1,0 @@
-﻿using System.Reflection;
-using EvoSC.Modules.Attributes;
-
-[assembly: ModuleIdentifier("ExampleModule")]
-[assembly: ModuleTitle("Example Module")]
-[assembly: ModuleSummary("An example module to get people started.")]
-[assembly: ModuleVersion("1.0.0")]
-[assembly: ModuleAuthor("snixtho")]

--- a/src/Modules/ExampleModule/info.toml
+++ b/src/Modules/ExampleModule/info.toml
@@ -1,0 +1,6 @@
+﻿[info]
+name = "ExampleModule"
+title = "Example Module"
+summary = "Just an example module."
+version = "1.0.0"
+author = "snixtho"

--- a/src/Modules/Player/Info.cs
+++ b/src/Modules/Player/Info.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using EvoSC.Modules.Attributes;
+
+[assembly: ModuleIdentifier("Player")]
+[assembly: ModuleTitle("Player Module")]
+[assembly: ModuleSummary("General player handling.")]
+[assembly: ModuleVersion("1.0.0")]
+[assembly: ModuleAuthor("snixtho")]

--- a/src/Modules/Player/Info.cs
+++ b/src/Modules/Player/Info.cs
@@ -1,8 +1,0 @@
-﻿using System.Reflection;
-using EvoSC.Modules.Attributes;
-
-[assembly: ModuleIdentifier("Player")]
-[assembly: ModuleTitle("Player Module")]
-[assembly: ModuleSummary("General player handling.")]
-[assembly: ModuleVersion("1.0.0")]
-[assembly: ModuleAuthor("snixtho")]

--- a/src/Modules/Player/Player.csproj
+++ b/src/Modules/Player/Player.csproj
@@ -9,7 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\EvoSC.Modules\EvoSC.Modules.csproj" />
+        <ProjectReference Include="..\..\EvoSC.Modules.SourceGeneration\EvoSC.Modules.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\EvoSC.Modules\EvoSC.Modules.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Modules/Player/Player.csproj
+++ b/src/Modules/Player/Player.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>EvoSC.Modules.Official.Player</RootNamespace>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Modules/Player/PlayerModule.cs
+++ b/src/Modules/Player/PlayerModule.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EvoSC.Modules.Official.Player;
 
-[Module(Name = "Player", Description = "General player handling.", IsInternal = true)]
+[Module(IsInternal = true)]
 public class PlayerModule : EvoScModule
 {
     

--- a/src/Modules/Player/info.toml
+++ b/src/Modules/Player/info.toml
@@ -1,0 +1,6 @@
+﻿[info]
+name = "Player"
+title = "Player Module"
+summary = "Module for handling and managing players."
+version = "1.0.0"
+author = "snixtho"


### PR DESCRIPTION
This pull request further progresses the module system with some fixes and new features, including:

- Ability to load external modules
- Implement the dependency system, allow modules to inject services from other modules
- Set up framework code for signing, the actual implementation not there yet
- Add ability to enable or disable modules at runtime.
- Source generation for metadata to make it easier to develop internal and external modules together.

Note: this is a breaking update and exiting modules must be updated.

**Updating existing modules**
You will now need to add a `info.toml` file to the module's project root. For internal modules, you don't need to have this copied to the output directory, but external modules are required to include this file.

An example of an `info.toml` file:
```toml
[info]
name = "ExampleModule"
title = "Example Module"
summary = "Just an example module."
version = "1.0.0"
author = "snixtho"

# this is completely optional
[dependencies]
Module1 = "1.0.0"
Module2 = "1.0.0"
# ...
```

The next step is only required for internal modules, in the `.csproj` file, add the following under `<ItemGroup>`:
```xml
<ProjectReference Include="..\..\EvoSC.Modules.SourceGeneration\EvoSC.Modules.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
```

This includes the necessary source generators for the assembly metadata.