### PR TITLE
Remove the original command interaction handler as it is no longer used.

### DIFF
--- a/src/EvoSC.Commands/Interfaces/ICommandInteractionHandler.cs
+++ b/src/EvoSC.Commands/Interfaces/ICommandInteractionHandler.cs
@@ -1,6 +1,0 @@
-﻿namespace EvoSC.Commands.Interfaces;
-
-public interface ICommandInteractionHandler
-{
-    
-}

--- a/src/EvoSC/Application.cs
+++ b/src/EvoSC/Application.cs
@@ -167,9 +167,6 @@ public sealed class Application : IEvoSCApplication, IDisposable
         _services.GetInstance<IServerCallbackHandler>();
         _services.GetInstance<IRemoteChatRouter>();
         await serverClient.StartAsync(_runningToken.Token);
-
-        // setup command handler
-        _services.GetInstance<ICommandInteractionHandler>();
     }
 
     public void Dispose()


### PR DESCRIPTION
Fixes an issue on startup where the application tries to access the original command interaction handler, but fails.