### PR TITLE
Add player cache, fixes #74

### DIFF
--- a/src/EvoSC.Common/Interfaces/Services/IPlayerCacheService.cs
+++ b/src/EvoSC.Common/Interfaces/Services/IPlayerCacheService.cs
@@ -1,0 +1,32 @@
+﻿using EvoSC.Common.Interfaces.Models;
+
+namespace EvoSC.Common.Interfaces.Services;
+
+public interface IPlayerCacheService
+{
+    /// <summary>
+    /// List of players currently on the server.
+    /// </summary>
+    public IEnumerable<IOnlinePlayer> OnlinePlayers { get; }
+
+    /// <summary>
+    /// Get an online player from the cache, and update the cache if not found.
+    /// </summary>
+    /// <param name="accountId">The account ID of the player to get.</param>
+    /// <returns></returns>
+    public Task<IOnlinePlayer?> GetOnlinePlayerCachedAsync(string accountId);
+    
+    /// <summary>
+    /// Get an online player from the cache, and update the cache if not found.
+    /// </summary>
+    /// <param name="accountId">The account ID of the player to get.</param>
+    /// <param name="forceUpdate">Force update the cache.</param>
+    /// <returns></returns>
+    public Task<IOnlinePlayer?> GetOnlinePlayerCachedAsync(string accountId, bool forceUpdate);
+
+    /// <summary>
+    /// Update the whole player list cache.
+    /// </summary>
+    /// <returns></returns>
+    public Task UpdatePlayerListAsync();
+}

--- a/src/EvoSC.Common/Remote/ChatRouter/RemoteChatRouter.cs
+++ b/src/EvoSC.Common/Remote/ChatRouter/RemoteChatRouter.cs
@@ -40,8 +40,6 @@ public class RemoteChatRouter : IRemoteChatRouter
     {
         try
         {
-            var sw = new Stopwatch();
-            sw.Start();
             var accountId = PlayerUtils.ConvertLoginToAccountId(e.Login);
             var player = await _players.GetOnlinePlayerAsync(accountId);
 
@@ -74,9 +72,6 @@ public class RemoteChatRouter : IRemoteChatRouter
                 MessageText = e.Text
             });
             
-            sw.Stop();
-            _logger.LogDebug("Chat router took: {Time} ms", sw.ElapsedMilliseconds);
-
             _logger.LogInformation("[{Name}]: {Msg}", player.StrippedNickName, e.Text);
         }
         catch (PlayerNotFoundException ex)

--- a/src/EvoSC.Common/Remote/ChatRouter/RemoteChatRouter.cs
+++ b/src/EvoSC.Common/Remote/ChatRouter/RemoteChatRouter.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using EvoSC.Common.Exceptions.PlayerExceptions;
+﻿using EvoSC.Common.Exceptions.PlayerExceptions;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Middleware;
 using EvoSC.Common.Interfaces.Services;

--- a/src/EvoSC.Common/Services/CommonServiceExtensions.cs
+++ b/src/EvoSC.Common/Services/CommonServiceExtensions.cs
@@ -14,6 +14,7 @@ public static class CommonServiceExtensions
     {
         services.Register<IPlayerManagerService, PlayerManagerService>(Lifestyle.Transient);
         services.Register<IMapService, MapService>(Lifestyle.Transient);
+        services.RegisterSingleton<IPlayerCacheService, PlayerCacheService>();
         
         return services;
     }

--- a/src/EvoSC.Common/Services/PlayerCacheService.cs
+++ b/src/EvoSC.Common/Services/PlayerCacheService.cs
@@ -112,14 +112,15 @@ public class PlayerCacheService : IPlayerCacheService
 
     private async Task OnPlayerConnectAsync(object sender, PlayerConnectEventArgs e)
     {
+        var accountId = PlayerUtils.ConvertLoginToAccountId(e.Login);
+        
         try
         {
-            var accountId = PlayerUtils.ConvertLoginToAccountId(e.Login);
             await ForceUpdatePlayerAsync(accountId);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to cache player");
+            _logger.LogError(ex, "Failed to cache player with account ID {AccountId}", accountId);
         }
     }
 
@@ -129,7 +130,8 @@ public class PlayerCacheService : IPlayerCacheService
 
         if (player == null)
         {
-            throw new InvalidOperationException("Tried to get online player, but the player object is null");
+            throw new InvalidOperationException(
+                $"Tried to get online player with account ID '{accountId}', but the player object is null");
         }
 
         lock (_onlinePlayersMutex)

--- a/src/EvoSC.Common/Services/PlayerCacheService.cs
+++ b/src/EvoSC.Common/Services/PlayerCacheService.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using EvoSC.Common.Events;
+﻿using EvoSC.Common.Events;
 using EvoSC.Common.Exceptions.PlayerExceptions;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Database.Repository;
@@ -11,7 +10,6 @@ using EvoSC.Common.Util;
 using GbxRemoteNet;
 using GbxRemoteNet.Events;
 using GbxRemoteNet.Structs;
-using GbxRemoteNet.XmlRpc;
 using Microsoft.Extensions.Logging;
 
 namespace EvoSC.Common.Services;
@@ -52,7 +50,7 @@ public class PlayerCacheService : IPlayerCacheService
             .WithEvent(GbxRemoteEvent.PlayerConnect)
             .WithInstance(this)
             .WithInstanceClass<PlayerCacheService>()
-            .WithHandlerMethod<PlayerConnectEventArgs>(OnPlayerConnect)
+            .WithHandlerMethod<PlayerConnectEventArgs>(OnPlayerConnectAsync)
             .WithPriority(EventPriority.High)
             .AsAsync()
         );
@@ -61,7 +59,7 @@ public class PlayerCacheService : IPlayerCacheService
             .WithEvent(GbxRemoteEvent.PlayerDisconnect)
             .WithInstance(this)
             .WithInstanceClass<PlayerCacheService>()
-            .WithHandlerMethod<PlayerDisconnectEventArgs>(OnPlayerDisconnect)
+            .WithHandlerMethod<PlayerDisconnectEventArgs>(OnPlayerDisconnectAsync)
             .WithPriority(EventPriority.High)
             .AsAsync()
         );
@@ -70,15 +68,15 @@ public class PlayerCacheService : IPlayerCacheService
             .WithEvent(GbxRemoteEvent.PlayerInfoChanged)
             .WithInstance(this)
             .WithInstanceClass<PlayerCacheService>()
-            .WithHandlerMethod<PlayerInfoChangedEventArgs>(OnPlayerInfoChanged)
+            .WithHandlerMethod<PlayerInfoChangedEventArgs>(OnPlayerInfoChangedAsync)
             .WithPriority(EventPriority.High)
             .AsAsync()
         );
 
-        _server.Remote.OnConnected += OnServerConnected;
+        _server.Remote.OnConnected += OnServerConnectedAsync;
     }
 
-    private async Task OnServerConnected()
+    private async Task OnServerConnectedAsync()
     {
         try
         {
@@ -91,13 +89,13 @@ public class PlayerCacheService : IPlayerCacheService
         }
     }
 
-    private async Task OnPlayerInfoChanged(object sender, PlayerInfoChangedEventArgs e)
+    private async Task OnPlayerInfoChangedAsync(object sender, PlayerInfoChangedEventArgs e)
     {
         var accountId = PlayerUtils.ConvertLoginToAccountId(e.PlayerInfo.Login);
         await ForceUpdatePlayerAsync(accountId);
     }
 
-    private Task OnPlayerDisconnect(object sender, PlayerDisconnectEventArgs e)
+    private Task OnPlayerDisconnectAsync(object sender, PlayerDisconnectEventArgs e)
     {
         var accountId = PlayerUtils.ConvertLoginToAccountId(e.Login);
 
@@ -112,7 +110,7 @@ public class PlayerCacheService : IPlayerCacheService
         return Task.CompletedTask;
     }
 
-    private async Task OnPlayerConnect(object sender, PlayerConnectEventArgs e)
+    private async Task OnPlayerConnectAsync(object sender, PlayerConnectEventArgs e)
     {
         try
         {

--- a/src/EvoSC.Common/Services/PlayerManagerService.cs
+++ b/src/EvoSC.Common/Services/PlayerManagerService.cs
@@ -68,7 +68,8 @@ public class PlayerManagerService : IPlayerManagerService
 
         if (player == null)
         {
-            throw new InvalidOperationException("Failed to get online player from cache.");
+            throw new InvalidOperationException(
+                $"Failed to get online player with account ID '{accountId}' from cache. Player object is null.");
         }
 
         return player;

--- a/src/EvoSC.Common/Services/PlayerManagerService.cs
+++ b/src/EvoSC.Common/Services/PlayerManagerService.cs
@@ -1,4 +1,5 @@
-﻿using EvoSC.Common.Exceptions.PlayerExceptions;
+﻿using System.Diagnostics;
+using EvoSC.Common.Exceptions.PlayerExceptions;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Database.Repository;
 using EvoSC.Common.Interfaces.Models;
@@ -15,12 +16,14 @@ public class PlayerManagerService : IPlayerManagerService
 {
     private readonly ILogger<PlayerManagerService> _logger;
     private readonly IPlayerRepository _playerRepository;
+    private readonly IPlayerCacheService _playerCache;
     private readonly IServerClient _server;
 
-    public PlayerManagerService(ILogger<PlayerManagerService> logger, IPlayerRepository playerRepository, IServerClient server)
+    public PlayerManagerService(ILogger<PlayerManagerService> logger, IPlayerRepository playerRepository, IPlayerCacheService playerCache, IServerClient server)
     {
         _logger = logger;
         _playerRepository = playerRepository;
+        _playerCache = playerCache;
         _server = server;
     }
 
@@ -64,62 +67,21 @@ public class PlayerManagerService : IPlayerManagerService
 
     public async Task<IOnlinePlayer> GetOnlinePlayerAsync(string accountId)
     {
-        var playerLogin = PlayerUtils.ConvertAccountIdToLogin(accountId);
-        // TODO: #74 Optimize Player State Fetching (https://github.com/EvoTM/EvoSC-sharp/issues/74)
-        var onlinePlayerInfo = await _server.Remote.GetPlayerInfoAsync(playerLogin);
-        var onlinePlayerDetails = await _server.Remote.GetDetailedPlayerInfoAsync(playerLogin);
-
-        if (onlinePlayerDetails == null || onlinePlayerInfo == null)
-        {
-            throw new PlayerNotFoundException(accountId, $"Cannot find online player: {accountId}");
-        }
-
-        var player = await GetOrCreatePlayerAsync(accountId);
+        var player = await _playerCache.GetOnlinePlayerCachedAsync(accountId);
 
         if (player == null)
         {
-            throw new PlayerNotFoundException(accountId);
+            throw new InvalidOperationException("Failed to get online player from cache.");
         }
 
-        return new OnlinePlayer(player)
-        {
-            State = onlinePlayerDetails.GetState(),
-            Flags = onlinePlayerInfo.GetFlags()
-        };
+        return player;
     }
 
     public Task<IOnlinePlayer> GetOnlinePlayerAsync(IPlayer player) => GetOnlinePlayerAsync(player.AccountId);
 
     public Task UpdateLastVisitAsync(IPlayer player) => _playerRepository.UpdateLastVisitAsync(player);
 
-    public async Task<IEnumerable<IOnlinePlayer>> GetOnlinePlayersAsync()
-    {
-        var players = new List<IOnlinePlayer>();
-        var onlinePlayers = await _server.Remote.GetPlayerListAsync();
-
-        foreach (var onlinePlayer in onlinePlayers)
-        {
-            var flags = onlinePlayer.GetFlags();
-            
-            if (flags.IsServer)
-            { 
-                // ignore server player as it's not a real player
-                continue;
-            }
-            
-            var accountId = PlayerUtils.ConvertLoginToAccountId(onlinePlayer.Login);
-            var playerDetails = await _server.Remote.GetDetailedPlayerInfoAsync(onlinePlayer.Login);
-            var player = await GetOrCreatePlayerAsync(accountId);
-            
-            players.Add(new OnlinePlayer(player)
-            {
-                State = playerDetails.GetState(),
-                Flags = flags
-            });
-        }
-
-        return players;
-    }
+    public Task<IEnumerable<IOnlinePlayer>> GetOnlinePlayersAsync() => Task.FromResult(_playerCache.OnlinePlayers);
 
     private const int MinMatchingCharacters = 2;
     

--- a/src/EvoSC.Common/Services/PlayerManagerService.cs
+++ b/src/EvoSC.Common/Services/PlayerManagerService.cs
@@ -1,10 +1,7 @@
-﻿using System.Diagnostics;
-using EvoSC.Common.Exceptions.PlayerExceptions;
-using EvoSC.Common.Interfaces;
+﻿using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Database.Repository;
 using EvoSC.Common.Interfaces.Models;
 using EvoSC.Common.Interfaces.Services;
-using EvoSC.Common.Models.Players;
 using EvoSC.Common.Util;
 using EvoSC.Common.Util.Algorithms;
 using GbxRemoteNet.Structs;

--- a/src/EvoSC.Common/Util/GbxRemoteExtensions.cs
+++ b/src/EvoSC.Common/Util/GbxRemoteExtensions.cs
@@ -1,0 +1,15 @@
+﻿using GbxRemoteNet.XmlRpc;
+
+namespace EvoSC.Common.Util;
+
+public static class GbxRemoteUtils
+{
+    /// <summary>
+    /// Convert a dynamic object to a native type.
+    /// </summary>
+    /// <param name="obj">Object to convert.</param>
+    /// <typeparam name="T">The native type to convert to.</typeparam>
+    /// <returns></returns>
+    public static T DynamicToType<T>(dynamic obj) =>
+        (T)XmlRpcTypes.ToNativeValue<T>(XmlRpcTypes.ToXmlRpcValue(obj));
+}

--- a/src/EvoSC/Application.cs
+++ b/src/EvoSC/Application.cs
@@ -10,6 +10,7 @@ using EvoSC.Common.Events;
 using EvoSC.Common.Interfaces;
 using EvoSC.Common.Interfaces.Controllers;
 using EvoSC.Common.Interfaces.Middleware;
+using EvoSC.Common.Interfaces.Services;
 using EvoSC.Common.Logging;
 using EvoSC.Common.Middleware;
 using EvoSC.Common.Permissions;
@@ -161,6 +162,9 @@ public sealed class Application : IEvoSCApplication, IDisposable
 
         // initialize event manager before anything else
         _services.GetInstance<IEventManager>();
+
+        // initialize player cache
+        _services.GetInstance<IPlayerCacheService>();
 
         // connect to the dedicated server and setup callbacks and chat router
         var serverClient = _services.GetInstance<IServerClient>();


### PR DESCRIPTION
From informal testing, the following optimization provides a ~1000x speedup from previously. The chat router is now 4x faster. An additional optimization was added to the chat router, by running the sending of chat messages to the server completely async, which gives the additional ~1000x speedup. Keep in mind that the delay between sending the message and it appearing on the server, remains at around ~50ms.